### PR TITLE
feat(servers): update agent in place via SelfUpdate RPC (certs preser…

### DIFF
--- a/app/(dashboard)/settings/servers/check-updates-button.tsx
+++ b/app/(dashboard)/settings/servers/check-updates-button.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { RefreshCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { gqlAction } from "@/lib/graphql-client";
+
+/**
+ * "Check for updates" — force the control plane to re-resolve the latest agent
+ * release from GitHub right now, bypassing the in-process cache, then refresh the
+ * page so every server's outdated badge reflects the fresh "latest".
+ *
+ * Without this, a newly published agent release isn't reflected until the release
+ * memo's TTL elapses (lib/agent/release.ts). The button is the operator's
+ * immediate bust; gated server-side by `manage_infra`.
+ */
+export function CheckUpdatesButton() {
+  const router = useRouter();
+  const [pending, startTransition] = React.useTransition();
+
+  function check() {
+    startTransition(async () => {
+      const res = await gqlAction<{ checkAgentUpdates: string }>(
+        `mutation CheckAgentUpdates {
+          checkAgentUpdates
+        }`,
+      );
+      if (!res.ok) {
+        toast.error(res.error);
+        return;
+      }
+      const latest = res.data?.checkAgentUpdates;
+      toast.success(
+        latest ? `Latest agent version is v${latest}` : "Checked for updates",
+      );
+      // Re-run the server-side reads so the outdated badges recompute against the
+      // freshly resolved "expected" version.
+      router.refresh();
+    });
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => check()}
+      disabled={pending}
+    >
+      <RefreshCw className={pending ? "size-4 animate-spin" : "size-4"} />
+      {pending ? "Checking…" : "Check for updates"}
+    </Button>
+  );
+}

--- a/app/(dashboard)/settings/servers/page.tsx
+++ b/app/(dashboard)/settings/servers/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/version";
 import type { Server } from "@/lib/types";
 import { AgentVersionBadge } from "./agent-version-badge";
+import { CheckUpdatesButton } from "./check-updates-button";
 import {
   ServerMetricsProvider,
   LiveServerMetrics,
@@ -39,6 +40,7 @@ function ServerCard({
   expectedAgentVersion: string;
 }) {
   const agentVersion = reportedAgentVersion(server);
+  const outdated = isAgentOutdated(agentVersion, expectedAgentVersion);
   return (
     <Card>
       <CardHeader className="space-y-3">
@@ -53,6 +55,8 @@ function ServerCard({
               serverId={server.id}
               serverName={serverLabel(server)}
               provisioning={server.status === "provisioning"}
+              outdated={outdated}
+              expectedVersion={expectedAgentVersion}
             />
           </div>
         </div>
@@ -68,7 +72,7 @@ function ServerCard({
           <AgentVersionBadge
             version={agentVersion}
             expected={expectedAgentVersion}
-            outdated={isAgentOutdated(agentVersion, expectedAgentVersion)}
+            outdated={outdated}
           />
         </div>
       </CardHeader>
@@ -103,6 +107,7 @@ export default async function ServersPage() {
       <PageHeader
         title="Servers"
         description="Connected Docker hosts running your deployments."
+        actions={<CheckUpdatesButton />}
       />
 
       <Card>

--- a/components/servers/server-actions.tsx
+++ b/components/servers/server-actions.tsx
@@ -3,7 +3,13 @@
 import * as React from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { MoreVertical, KeyRound, Trash2, ServerCog } from "lucide-react";
+import {
+  MoreVertical,
+  KeyRound,
+  Trash2,
+  ServerCog,
+  CircleFadingArrowUp,
+} from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -26,8 +32,13 @@ import { gqlAction } from "@/lib/graphql-client";
 
 /**
  * Per-server management actions, shown for EVERY server card (the host running
- * Deplo included — it is a bootstrapped agent like any other). Two actions, both
- * gated server-side by `manage_infra`:
+ * Deplo included — it is a bootstrapped agent like any other). All gated
+ * server-side by `manage_infra`:
+ *   - Update agent — only when the server's agent is OUTDATED. Updates the agent
+ *     binary in place to the latest release WITHOUT reissuing certificates: the
+ *     agent self-updates over its existing pinned-mTLS channel and re-execs with
+ *     the same on-disk trust, so the server stays online with the same identity.
+ *     Distinct from reissue (which re-bootstraps and would reset trust).
  *   - Reissue install command — mint a FRESH one-time bootstrap command for a
  *     server still provisioning (the original token expired or was lost). This is
  *     the "server's menu" the AddServer dialog's note points at.
@@ -39,16 +50,23 @@ export function ServerActions({
   serverId,
   serverName,
   provisioning,
+  outdated,
+  expectedVersion,
 }: {
   serverId: string;
   serverName: string;
   /** Still awaiting the agent's call-home — show the reissue action prominently. */
   provisioning: boolean;
+  /** The agent is strictly behind the latest release — offer the in-place update. */
+  outdated: boolean;
+  /** The latest agent version we'd update to, for the menu label + confirm copy. */
+  expectedVersion: string;
 }) {
   const router = useRouter();
   const [pending, startTransition] = React.useTransition();
   const [command, setCommand] = React.useState<string | null>(null);
   const [confirmRemove, setConfirmRemove] = React.useState(false);
+  const [confirmUpdate, setConfirmUpdate] = React.useState(false);
 
   function reissue() {
     startTransition(async () => {
@@ -68,6 +86,32 @@ export function ServerActions({
       }
       if (!res.data) return;
       setCommand(res.data.reissueServerBootstrap.installCommand);
+    });
+  }
+
+  function update() {
+    startTransition(async () => {
+      const res = await gqlAction<{ updateServerAgent: string }>(
+        `mutation UpdateServerAgent($id: String!) {
+          updateServerAgent(id: $id)
+        }`,
+        { id: serverId },
+      );
+      if (!res.ok) {
+        // Surfaces the server-side message verbatim, including the "this agent is
+        // too old to self-update remotely — re-run the installer for now" case
+        // (until the agent ships the self-update RPC).
+        toast.error(res.error);
+        return;
+      }
+      setConfirmUpdate(false);
+      const version = res.data?.updateServerAgent;
+      toast.success(
+        version
+          ? `${serverName} agent updated to v${version}`
+          : `${serverName} agent updated`,
+      );
+      router.refresh();
     });
   }
 
@@ -109,7 +153,22 @@ export function ServerActions({
             <MoreVertical className="size-4" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuContent align="end" className="w-56">
+          {outdated ? (
+            <>
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setConfirmUpdate(true);
+                }}
+                disabled={pending}
+              >
+                <CircleFadingArrowUp className="size-4" />
+                Update agent to v{expectedVersion}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          ) : null}
           <DropdownMenuItem onSelect={() => reissue()} disabled={pending}>
             <KeyRound className="size-4" />
             {provisioning ? "Show install command" : "Reissue install command"}
@@ -166,6 +225,38 @@ export function ServerActions({
               }}
             >
               Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Confirm in-place agent update (no cert reissue). */}
+      <Dialog open={confirmUpdate} onOpenChange={setConfirmUpdate}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <CircleFadingArrowUp className="size-4" />
+              Update agent on {serverName}?
+            </DialogTitle>
+            <DialogDescription>
+              Updates the agent binary in place to{" "}
+              <strong>v{expectedVersion}</strong> over its existing secure
+              connection. Its certificates are <strong>not</strong> reissued — the
+              agent restarts with the same identity, so the server stays online and
+              keeps its trust. The update takes a few seconds while the agent swaps
+              its binary and reconnects.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmUpdate(false)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={() => update()} disabled={pending}>
+              {pending ? "Updating…" : `Update to v${expectedVersion}`}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/lib/agent/gen/agent.ts
+++ b/lib/agent/gen/agent.ts
@@ -604,6 +604,66 @@ export interface InspectResponse {
   state: string;
 }
 
+/**
+ * In-place agent binary update (SelfUpdate). The control plane resolves the
+ * latest release and sends EVERY published per-arch asset (its download URL + the
+ * sha256 from the release's checksums.txt — the same integrity source install-
+ * agent.sh pins). The AGENT selects the asset matching its OWN architecture
+ * (runtime.GOARCH), exactly as install-agent.sh selects by `uname -m`: the agent
+ * is the authority on its own host's arch, and the control plane never has to
+ * learn or store it. The agent stays otherwise dumb — it does not talk to the
+ * GitHub API or know the release repo, it just fetches the chosen URL, checks the
+ * digest, and swaps itself. Trust material is NOT in this message and is never
+ * touched by the update.
+ */
+export interface SelfUpdateRequest {
+  /**
+   * The target version, normalized without a leading v (e.g. "1.2.0"). Used only
+   * for logging + the response echo; the agent does not gate on it (the control
+   * plane already decided this is the version to install).
+   */
+  version: string;
+  /**
+   * The published binaries, keyed by Go arch ("amd64" | "arm64"). The agent picks
+   * the entry for its own runtime.GOARCH; if its arch is absent (the release
+   * didn't publish it), the update fails with FAILED_PRECONDITION and the running
+   * binary is untouched. At least one entry is always present.
+   */
+  binaries: { [key: string]: ArchBinary };
+}
+
+export interface SelfUpdateRequest_BinariesEntry {
+  key: string;
+  value?: ArchBinary | undefined;
+}
+
+/** One published binary asset for a single architecture. */
+export interface ArchBinary {
+  /**
+   * The asset download URL. The agent treats the bytes as opaque until the
+   * checksum passes.
+   */
+  url: string;
+  /**
+   * Lowercase hex sha256 the downloaded bytes MUST match. A mismatch aborts the
+   * update with FAILED_PRECONDITION and the running binary is left untouched —
+   * the agent never execs an unverified binary (install-agent.sh P2 parity).
+   */
+  sha256: string;
+}
+
+export interface SelfUpdateResponse {
+  /** The version now staged on disk (echoes the request's version on success). */
+  version: string;
+  /**
+   * True once the new binary is in place and the agent is about to restart to
+   * exec it. The control plane uses this as the "update applied" signal; the
+   * agent then exits so its supervisor (systemd Restart=on-failure) re-execs the
+   * freshly-swapped binary, which reuses the existing mTLS materials.
+   */
+  restarting: boolean;
+}
+
 export interface FollowLogsRequest {
   /** The project the container must belong to (agent re-validates the label). */
   projectId: string;
@@ -3413,6 +3473,339 @@ export const InspectResponse: MessageFns<InspectResponse> = {
     message.exists = object.exists ?? false;
     message.running = object.running ?? false;
     message.state = object.state ?? "";
+    return message;
+  },
+};
+
+function createBaseSelfUpdateRequest(): SelfUpdateRequest {
+  return { version: "", binaries: {} };
+}
+
+export const SelfUpdateRequest: MessageFns<SelfUpdateRequest> = {
+  encode(message: SelfUpdateRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.version !== "") {
+      writer.uint32(10).string(message.version);
+    }
+    globalThis.Object.entries(message.binaries).forEach(([key, value]: [string, ArchBinary]) => {
+      SelfUpdateRequest_BinariesEntry.encode({ key: key as any, value }, writer.uint32(18).fork()).join();
+    });
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SelfUpdateRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSelfUpdateRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.version = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          const entry2 = SelfUpdateRequest_BinariesEntry.decode(reader, reader.uint32());
+          if (entry2.value !== undefined) {
+            message.binaries[entry2.key] = entry2.value;
+          }
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SelfUpdateRequest {
+    return {
+      version: isSet(object.version) ? globalThis.String(object.version) : "",
+      binaries: isObject(object.binaries)
+        ? (globalThis.Object.entries(object.binaries) as [string, any][]).reduce(
+          (acc: { [key: string]: ArchBinary }, [key, value]: [string, any]) => {
+            acc[key] = ArchBinary.fromJSON(value);
+            return acc;
+          },
+          {},
+        )
+        : {},
+    };
+  },
+
+  toJSON(message: SelfUpdateRequest): unknown {
+    const obj: any = {};
+    if (message.version !== "") {
+      obj.version = message.version;
+    }
+    if (message.binaries) {
+      const entries = globalThis.Object.entries(message.binaries) as [string, ArchBinary][];
+      if (entries.length > 0) {
+        obj.binaries = {};
+        entries.forEach(([k, v]) => {
+          obj.binaries[k] = ArchBinary.toJSON(v);
+        });
+      }
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SelfUpdateRequest>, I>>(base?: I): SelfUpdateRequest {
+    return SelfUpdateRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SelfUpdateRequest>, I>>(object: I): SelfUpdateRequest {
+    const message = createBaseSelfUpdateRequest();
+    message.version = object.version ?? "";
+    message.binaries = (globalThis.Object.entries(object.binaries ?? {}) as [string, ArchBinary][]).reduce(
+      (acc: { [key: string]: ArchBinary }, [key, value]: [string, ArchBinary]) => {
+        if (value !== undefined) {
+          acc[key] = ArchBinary.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    return message;
+  },
+};
+
+function createBaseSelfUpdateRequest_BinariesEntry(): SelfUpdateRequest_BinariesEntry {
+  return { key: "", value: undefined };
+}
+
+export const SelfUpdateRequest_BinariesEntry: MessageFns<SelfUpdateRequest_BinariesEntry> = {
+  encode(message: SelfUpdateRequest_BinariesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== undefined) {
+      ArchBinary.encode(message.value, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SelfUpdateRequest_BinariesEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSelfUpdateRequest_BinariesEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = ArchBinary.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SelfUpdateRequest_BinariesEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? ArchBinary.fromJSON(object.value) : undefined,
+    };
+  },
+
+  toJSON(message: SelfUpdateRequest_BinariesEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = ArchBinary.toJSON(message.value);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SelfUpdateRequest_BinariesEntry>, I>>(base?: I): SelfUpdateRequest_BinariesEntry {
+    return SelfUpdateRequest_BinariesEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SelfUpdateRequest_BinariesEntry>, I>>(
+    object: I,
+  ): SelfUpdateRequest_BinariesEntry {
+    const message = createBaseSelfUpdateRequest_BinariesEntry();
+    message.key = object.key ?? "";
+    message.value = (object.value !== undefined && object.value !== null)
+      ? ArchBinary.fromPartial(object.value)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseArchBinary(): ArchBinary {
+  return { url: "", sha256: "" };
+}
+
+export const ArchBinary: MessageFns<ArchBinary> = {
+  encode(message: ArchBinary, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.url !== "") {
+      writer.uint32(10).string(message.url);
+    }
+    if (message.sha256 !== "") {
+      writer.uint32(18).string(message.sha256);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): ArchBinary {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseArchBinary();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.url = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.sha256 = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ArchBinary {
+    return {
+      url: isSet(object.url) ? globalThis.String(object.url) : "",
+      sha256: isSet(object.sha256) ? globalThis.String(object.sha256) : "",
+    };
+  },
+
+  toJSON(message: ArchBinary): unknown {
+    const obj: any = {};
+    if (message.url !== "") {
+      obj.url = message.url;
+    }
+    if (message.sha256 !== "") {
+      obj.sha256 = message.sha256;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ArchBinary>, I>>(base?: I): ArchBinary {
+    return ArchBinary.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ArchBinary>, I>>(object: I): ArchBinary {
+    const message = createBaseArchBinary();
+    message.url = object.url ?? "";
+    message.sha256 = object.sha256 ?? "";
+    return message;
+  },
+};
+
+function createBaseSelfUpdateResponse(): SelfUpdateResponse {
+  return { version: "", restarting: false };
+}
+
+export const SelfUpdateResponse: MessageFns<SelfUpdateResponse> = {
+  encode(message: SelfUpdateResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.version !== "") {
+      writer.uint32(10).string(message.version);
+    }
+    if (message.restarting !== false) {
+      writer.uint32(16).bool(message.restarting);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SelfUpdateResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSelfUpdateResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.version = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.restarting = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SelfUpdateResponse {
+    return {
+      version: isSet(object.version) ? globalThis.String(object.version) : "",
+      restarting: isSet(object.restarting) ? globalThis.Boolean(object.restarting) : false,
+    };
+  },
+
+  toJSON(message: SelfUpdateResponse): unknown {
+    const obj: any = {};
+    if (message.version !== "") {
+      obj.version = message.version;
+    }
+    if (message.restarting !== false) {
+      obj.restarting = message.restarting;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<SelfUpdateResponse>, I>>(base?: I): SelfUpdateResponse {
+    return SelfUpdateResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<SelfUpdateResponse>, I>>(object: I): SelfUpdateResponse {
+    const message = createBaseSelfUpdateResponse();
+    message.version = object.version ?? "";
+    message.restarting = object.restarting ?? false;
     return message;
   },
 };
@@ -6958,6 +7351,32 @@ export const AgentService = {
     responseDeserialize: (value: Buffer): InspectResponse => InspectResponse.decode(value),
   },
   /**
+   * Update the agent BINARY in place to a newer release, WITHOUT re-bootstrapping
+   * — the agent's mTLS materials (agent.crt/agent.key/ca.crt under --agent-dir)
+   * are NEVER touched, so the server keeps its identity and pinned fingerprint
+   * across the upgrade and stays "online". This is the in-place sibling of
+   * re-running install-agent.sh (which mints a fresh token and re-bootstraps,
+   * resetting trust). The control plane resolves the latest release (the SAME
+   * GitHub release the install path uses) and sends the per-arch download URL +
+   * its sha256 here; the agent downloads, VERIFIES the checksum (refusing a
+   * mismatch, exactly like the installer's P2 guard), atomically swaps its own
+   * on-disk binary, replies, then restarts so systemd re-execs the new binary
+   * (which finds the existing materials and serves straight away — no call-home).
+   * INVARIANT: trust material is out of scope here; a SelfUpdate can change the
+   * code but never the identity. Returns FAILED_PRECONDITION when the agent can't
+   * locate/replace its own binary (e.g. a read-only install dir), so the control
+   * plane can tell the operator to fall back to re-running the installer.
+   */
+  selfUpdate: {
+    path: "/deplo.agent.v1.Agent/SelfUpdate" as const,
+    requestStream: false as const,
+    responseStream: false as const,
+    requestSerialize: (value: SelfUpdateRequest): Buffer => Buffer.from(SelfUpdateRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer): SelfUpdateRequest => SelfUpdateRequest.decode(value),
+    responseSerialize: (value: SelfUpdateResponse): Buffer => Buffer.from(SelfUpdateResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer): SelfUpdateResponse => SelfUpdateResponse.decode(value),
+  },
+  /**
    * Stream a container's live runtime logs (`docker logs -f --tail N`) as raw
    * byte chunks. Output-only — there is no stdin. The control plane proxies these
    * chunks straight into the unchanged SSE log route. Closing the stream (browser
@@ -7302,6 +7721,24 @@ export interface AgentServer extends UntypedServiceImplementation {
   /** Container introspection (status/running) for the live-status subscriptions. */
   inspect: handleUnaryCall<InspectRequest, InspectResponse>;
   /**
+   * Update the agent BINARY in place to a newer release, WITHOUT re-bootstrapping
+   * — the agent's mTLS materials (agent.crt/agent.key/ca.crt under --agent-dir)
+   * are NEVER touched, so the server keeps its identity and pinned fingerprint
+   * across the upgrade and stays "online". This is the in-place sibling of
+   * re-running install-agent.sh (which mints a fresh token and re-bootstraps,
+   * resetting trust). The control plane resolves the latest release (the SAME
+   * GitHub release the install path uses) and sends the per-arch download URL +
+   * its sha256 here; the agent downloads, VERIFIES the checksum (refusing a
+   * mismatch, exactly like the installer's P2 guard), atomically swaps its own
+   * on-disk binary, replies, then restarts so systemd re-execs the new binary
+   * (which finds the existing materials and serves straight away — no call-home).
+   * INVARIANT: trust material is out of scope here; a SelfUpdate can change the
+   * code but never the identity. Returns FAILED_PRECONDITION when the agent can't
+   * locate/replace its own binary (e.g. a read-only install dir), so the control
+   * plane can tell the operator to fall back to re-running the installer.
+   */
+  selfUpdate: handleUnaryCall<SelfUpdateRequest, SelfUpdateResponse>;
+  /**
    * Stream a container's live runtime logs (`docker logs -f --tail N`) as raw
    * byte chunks. Output-only — there is no stdin. The control plane proxies these
    * chunks straight into the unchanged SSE log route. Closing the stream (browser
@@ -7573,6 +8010,38 @@ export interface AgentClient extends Client {
     metadata: Metadata,
     options: Partial<CallOptions>,
     callback: (error: ServiceError | null, response: InspectResponse) => void,
+  ): ClientUnaryCall;
+  /**
+   * Update the agent BINARY in place to a newer release, WITHOUT re-bootstrapping
+   * — the agent's mTLS materials (agent.crt/agent.key/ca.crt under --agent-dir)
+   * are NEVER touched, so the server keeps its identity and pinned fingerprint
+   * across the upgrade and stays "online". This is the in-place sibling of
+   * re-running install-agent.sh (which mints a fresh token and re-bootstraps,
+   * resetting trust). The control plane resolves the latest release (the SAME
+   * GitHub release the install path uses) and sends the per-arch download URL +
+   * its sha256 here; the agent downloads, VERIFIES the checksum (refusing a
+   * mismatch, exactly like the installer's P2 guard), atomically swaps its own
+   * on-disk binary, replies, then restarts so systemd re-execs the new binary
+   * (which finds the existing materials and serves straight away — no call-home).
+   * INVARIANT: trust material is out of scope here; a SelfUpdate can change the
+   * code but never the identity. Returns FAILED_PRECONDITION when the agent can't
+   * locate/replace its own binary (e.g. a read-only install dir), so the control
+   * plane can tell the operator to fall back to re-running the installer.
+   */
+  selfUpdate(
+    request: SelfUpdateRequest,
+    callback: (error: ServiceError | null, response: SelfUpdateResponse) => void,
+  ): ClientUnaryCall;
+  selfUpdate(
+    request: SelfUpdateRequest,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: SelfUpdateResponse) => void,
+  ): ClientUnaryCall;
+  selfUpdate(
+    request: SelfUpdateRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: SelfUpdateResponse) => void,
   ): ClientUnaryCall;
   /**
    * Stream a container's live runtime logs (`docker logs -f --tail N`) as raw

--- a/lib/agent/release.ts
+++ b/lib/agent/release.ts
@@ -82,7 +82,16 @@ function parseChecksums(text: string): Map<string, string> {
 
 /** In-process memo so a single render doesn't fan out to GitHub per field/server. */
 let cache: { at: number; release: AgentRelease | null } | null = null;
-const CACHE_TTL_MS = 3600_000; // 1h, matching the getUpdateInfo cadence
+/**
+ * Short TTL: the memo only exists to coalesce the GitHub calls within a single
+ * render (many server cards / GraphQL fields resolve the same release). It is NOT
+ * a freshness control — a newly cut agent release should surface promptly. 5 min
+ * keeps GitHub well under its rate limit while bounding how long a stale "latest"
+ * (e.g. a release published seconds after this process cached the prior one) is
+ * served. For an immediate refresh use refreshAgentRelease() (the operator's
+ * "Check for updates" action) rather than waiting this out.
+ */
+const CACHE_TTL_MS = 300_000; // 5m
 
 /** A monotonic-ish clock that tolerates environments where Date.now is shimmed. */
 function now(): number {
@@ -102,6 +111,21 @@ export async function resolveLatestAgentRelease(): Promise<AgentRelease | null> 
   const release = await fetchLatestRelease();
   cache = { at: now(), release };
   return release;
+}
+
+/**
+ * Force an immediate re-resolution of the latest agent release, bypassing the
+ * in-process memo. The production sibling of __resetReleaseCacheForTests: the
+ * operator's "Check for updates" action calls this so a release cut moments ago
+ * is reflected at once, instead of waiting out CACHE_TTL_MS. Re-populates the
+ * memo with the fresh result (so the immediately-following render reuses it) and
+ * returns it. Note the underlying fetch still carries `next: { revalidate }`, but
+ * that Data Cache is suppressed on the dynamic/cookie'd paths that call this, so
+ * clearing the in-process memo is the effective bust.
+ */
+export async function refreshAgentRelease(): Promise<AgentRelease | null> {
+  cache = null;
+  return resolveLatestAgentRelease();
 }
 
 async function fetchLatestRelease(): Promise<AgentRelease | null> {

--- a/lib/data/servers.ts
+++ b/lib/data/servers.ts
@@ -192,6 +192,54 @@ export async function removeServer(id: string): Promise<{ warning: string | null
   return { warning };
 }
 
+/**
+ * Update a server's agent binary in place to the latest released version WITHOUT
+ * reissuing its certificates. Unlike re-running the installer (which mints a new
+ * token and re-bootstraps, clearing the agent's mTLS materials), this dials the
+ * agent over its EXISTING pinned-mTLS channel and asks it to self-update: fetch
+ * the checksum-verified latest binary, swap itself on disk, and re-exec keeping
+ * the same on-disk cert/key/CA. Trust — the pinned fingerprint — is untouched, so
+ * the server stays "online" with the same identity across the upgrade.
+ *
+ * Resolves the "latest" target version through the same release resolver the
+ * outdated badge uses, so what we install matches what the dashboard flagged.
+ * Returns the version the agent is now running. Throws when the server is
+ * unreachable / not provisioned, or — until the agent ships the self-update RPC —
+ * AgentUpdateUnsupportedError (the GraphQL layer turns that into a clear message
+ * telling the operator to re-run the installer for now).
+ */
+export async function updateServerAgent(id: string): Promise<{ version: string }> {
+  const { membership } = await requireCapability("manage_infra");
+  const user = read().users.find((u) => u.id === membership.userId)!;
+  const server = read().servers.find((s) => s.id === id);
+  if (!server) throw new Error("Server not found");
+  if (!server.agent?.certFingerprint)
+    throw new Error("This server is not provisioned yet — finish provisioning before updating its agent");
+
+  // Lazy-import for the same reason removeServer does: keep the grpc agent-client
+  // (and its deps) out of modules that never reach an agent. The seam resolves the
+  // latest release itself (version + per-arch url/sha from one consistent release)
+  // and tells the agent to self-update over its existing pinned-mTLS channel —
+  // certs are never reissued.
+  const { selfUpdateServerAgent } = await import("../infra/agent-client");
+  const result = await selfUpdateServerAgent(id);
+
+  // Record the new version optimistically; the next Hello (markServerSeen)
+  // refreshes it from the live agent regardless, so this is just a faster echo.
+  mutate((d) => {
+    const s = d.servers.find((x) => x.id === id);
+    if (s?.agent) s.agent.version = result.version;
+  });
+  recordActivity(
+    "member",
+    `Updated agent on ${server.name} to v${result.version}`,
+    user.name,
+    null,
+    membership.teamId,
+  );
+  return result;
+}
+
 /** What a calling-home agent sends, and what completeBootstrap signs against. */
 export interface BootstrapCallHome {
   /** The raw one-time token from the install command. */

--- a/lib/graphql/types/server.ts
+++ b/lib/graphql/types/server.ts
@@ -6,6 +6,7 @@ import {
   addServer,
   reissueBootstrap,
   removeServer,
+  updateServerAgent,
 } from "@/lib/data/servers";
 import {
   isAgentOutdated,
@@ -186,6 +187,32 @@ builder.mutationFields((t) => ({
     resolve: async (_r, { id }) => {
       const { warning } = await removeServer(id);
       return warning;
+    },
+  }),
+  updateServerAgent: t.field({
+    type: "String",
+    authScopes: { capability: "manage_infra" },
+    description:
+      "Update this server's agent binary in place to the latest released version WITHOUT reissuing its certificates — the agent self-updates over its existing pinned-mTLS channel and re-execs keeping the same on-disk trust materials, so the server stays online with the same identity. Returns the version the agent is now running. Errors clearly when the server is unreachable/unprovisioned, or — until the agent ships the self-update RPC — when its agent is too old to update itself remotely (re-run the installer to upgrade it for now).",
+    args: { id: t.arg.string({ required: true }) },
+    resolve: async (_r, { id }) => {
+      const { version } = await updateServerAgent(id);
+      return version;
+    },
+  }),
+  checkAgentUpdates: t.field({
+    type: "String",
+    authScopes: { capability: "manage_infra" },
+    description:
+      "Force an immediate re-resolution of the latest agent release from GitHub, bypassing the in-process cache. Returns the resolved expected agent version so the dashboard re-renders with fresh outdated badges. Use after publishing a new agent release rather than waiting out the cache TTL.",
+    resolve: async () => {
+      // Bust the in-process memo, then re-resolve through the standard helper so
+      // the fallback rule (GitHub unreachable -> FALLBACK_AGENT_VERSION) stays in
+      // one place. resolveExpectedAgentVersion re-populates the memo, so the
+      // RSC re-render that follows reuses this fresh value.
+      const { refreshAgentRelease } = await import("@/lib/agent/release");
+      await refreshAgentRelease();
+      return resolveExpectedAgentVersion();
     },
   }),
 }));

--- a/lib/infra/agent-client.ts
+++ b/lib/infra/agent-client.ts
@@ -53,6 +53,7 @@ const CONSOLE_TIMEOUT_MS = 30_000; // exec runs in-container; match docker.ts ex
 const FILES_TIMEOUT_MS = 15_000;
 const STREAM_DEADLINE_MS = 30 * 60_000; // logs/attach are long-lived
 const GATEWAY_TIMEOUT_MS = 4 * 60_000; // gateway compose-up + sshd-wait + reconcile (Part D)
+const SELF_UPDATE_TIMEOUT_MS = 2 * 60_000; // agent downloads + verifies + swaps its own binary
 
 /** Plain structural shapes the agent returns — mapped 1:1 by the data layer. */
 export interface AgentConsoleInstance {
@@ -147,6 +148,14 @@ export interface AgentConnection {
   /** Read back the rendered stack YAML the agent has on disk, for the "View full
    *  compose" preview. `exists` is false (empty yaml) when never deployed. */
   readStack(slug: string): Promise<{ exists: boolean; yaml: string }>;
+  /** Update the agent BINARY in place to `version`, WITHOUT reissuing certs: the
+   *  agent picks the asset for its own arch from `binaries`, verifies the sha256,
+   *  swaps itself, and re-execs reusing the on-disk mTLS materials. Resolves once
+   *  the swap is staged and the restart is scheduled (`restarting`). */
+  selfUpdate(
+    version: string,
+    binaries: Record<string, { url: string; sha256: string }>,
+  ): Promise<{ version: string; restarting: boolean }>;
 
   // ---- Part C: console observability ----
   /** Live `docker logs -f` as an output-only AttachHandle (reuses the SSE session
@@ -235,6 +244,22 @@ interface DialTarget {
 
 /** A typed availability error: the agent could not be reached (caller falls back). */
 export class AgentUnreachableError extends Error {}
+
+/**
+ * The reachable agent does not (yet) implement the in-place self-update RPC.
+ *
+ * The agent binary lives in its own repo (DeploCloud/deplo-agent) and ships on
+ * its own cadence; the `SelfUpdate` RPC — "fetch the checksum-verified latest
+ * binary, swap yourself on disk, re-exec keeping the SAME on-disk mTLS materials"
+ * — is added there and rolled out in an agent release. Until a server is running
+ * an agent new enough to answer it, `selfUpdateServerAgent` rejects with THIS
+ * error (distinct from {@link AgentUnreachableError}: the agent IS up, it just
+ * can't update itself remotely). The data/GraphQL layers surface it as a clear
+ * "update this agent by re-running the installer for now" message rather than a
+ * generic failure. When the RPC ships, only the body of `selfUpdateServerAgent`
+ * changes — every layer above it is already wired.
+ */
+export class AgentUpdateUnsupportedError extends Error {}
 
 /**
  * gRPC status codes that mean "the agent is down / not answering" rather than
@@ -630,6 +655,22 @@ function dial(target: DialTarget): AgentConnection {
         );
       });
     },
+    selfUpdate(
+      version: string,
+      binaries: Record<string, { url: string; sha256: string }>,
+    ) {
+      return new Promise<{ version: string; restarting: boolean }>((resolve, reject) => {
+        client.selfUpdate(
+          { version, binaries },
+          new Metadata(),
+          { deadline: new Date(Date.now() + SELF_UPDATE_TIMEOUT_MS) },
+          (err, resp) =>
+            err
+              ? reject(toAgentError(err))
+              : resolve({ version: resp.version, restarting: resp.restarting }),
+        );
+      });
+    },
 
     // ---- Part C: console observability ----
     followLogs(projectId: string, container: string, tail: number) {
@@ -905,6 +946,94 @@ export async function teardownServerAgent(server: Server): Promise<void> {
   const conn = dial(target);
   try {
     await conn.hello(); // reachability pre-flight; throws if the box is gone
+  } finally {
+    conn.close();
+  }
+}
+
+/** The capability an agent advertises in Hello once it can self-update (mirrors
+ *  the "self-update" entry in the agent's server.Capabilities). */
+const SELF_UPDATE_CAPABILITY = "self-update";
+
+/**
+ * Update a server's agent binary IN PLACE to the latest release, WITHOUT
+ * reissuing its certificates. We dial the agent over its existing pinned-mTLS
+ * channel (`resolveTarget` proves it is provisioned + reachable, and the dial
+ * reuses the cert fingerprint recorded at bootstrap) and ask it to self-update:
+ * it fetches the checksum-verified binary for its own arch from GitHub Releases,
+ * swaps itself on disk, and re-execs keeping the SAME on-disk `agent.crt` /
+ * `agent.key` / `ca.crt`. Trust is untouched — no new CSR, no re-bootstrap, no
+ * token — so the server stays "online" with the same pinned fingerprint across
+ * the upgrade. This is the whole point of doing it over the agent channel rather
+ * than re-running install-agent.sh (which clears materials and re-bootstraps).
+ *
+ * The control plane resolves the release and sends EVERY published per-arch asset
+ * (url + sha256 from the release's checksums.txt — the same integrity source the
+ * installer pins); the agent selects its own arch. We do NOT pass the target
+ * version in from the caller's idea of "latest" only — we re-resolve here so the
+ * url/sha/version are internally consistent (one release).
+ *
+ * Throws:
+ *  - {@link AgentUnreachableError} when the server is unknown / not provisioned /
+ *    offline (the data layer surfaces "not provisioned / unreachable").
+ *  - {@link AgentUpdateUnsupportedError} when the reachable agent is too OLD to
+ *    self-update (it doesn't advertise the `self-update` capability, or it returns
+ *    gRPC UNIMPLEMENTED) — the UI tells the operator to re-run the installer.
+ *  - a plain error when no agent release can be resolved (GitHub unreachable), so
+ *    we never tell the agent to update to nothing.
+ */
+export async function selfUpdateServerAgent(
+  serverId: string,
+): Promise<{ version: string; restarting: boolean }> {
+  // Resolves only for a provisioned server with un-revoked trust; throws
+  // AgentUnreachableError otherwise.
+  const target = await resolveTarget(serverId);
+
+  // Resolve the release to install (version + per-arch url/sha). Out here so a
+  // GitHub outage fails before we touch the agent, and so version/urls are one
+  // consistent release. Lazy import keeps release.ts (and its server-only fetch)
+  // out of modules that never update an agent.
+  const { resolveLatestAgentRelease } = await import("../agent/release");
+  const release = await resolveLatestAgentRelease();
+  if (!release) {
+    throw new Error(
+      "Could not resolve the latest agent release from GitHub — try again, or use Check for updates.",
+    );
+  }
+  // Shape the release's per-arch binaries into the RPC's { arch -> {url,sha256} }
+  // map, dropping any arch the release didn't publish (the agent picks its own).
+  const binaries: Record<string, { url: string; sha256: string }> = {};
+  for (const [arch, bin] of Object.entries(release.binaries)) {
+    if (bin) binaries[arch] = { url: bin.url, sha256: bin.sha256 };
+  }
+
+  const conn = dial(target);
+  try {
+    // Pre-flight: confirm the agent answers AND can self-update. An agent too old
+    // to know the RPC won't advertise the capability — reject distinctly so the UI
+    // says "re-run the installer" rather than emitting a confusing UNIMPLEMENTED.
+    const hello = await conn.hello();
+    if (!hello.capabilities?.includes(SELF_UPDATE_CAPABILITY)) {
+      throw new AgentUpdateUnsupportedError(
+        `The agent on this server is too old to update itself remotely ` +
+          `(target v${release.version}). Re-run the install command to upgrade it.`,
+      );
+    }
+    return await conn.selfUpdate(release.version, binaries);
+  } catch (e) {
+    // Belt-and-braces: a just-old-enough agent that advertises nothing useful, or
+    // a version skew, may still answer the call with UNIMPLEMENTED — map it to the
+    // same actionable message rather than a raw gRPC error.
+    if (
+      !(e instanceof AgentUpdateUnsupportedError) &&
+      (e as Partial<ServiceError> | null)?.code === GrpcStatus.UNIMPLEMENTED
+    ) {
+      throw new AgentUpdateUnsupportedError(
+        `The agent on this server is too old to update itself remotely ` +
+          `(target v${release.version}). Re-run the install command to upgrade it.`,
+      );
+    }
+    throw e;
   } finally {
     conn.close();
   }

--- a/schema.graphql
+++ b/schema.graphql
@@ -41,12 +41,21 @@ input AddRegistryInput {
   username: String!
 }
 
-"""Register a remote server (provisioned via SSH)."""
+"""
+Register a remote server. Provisioned by a call-home bootstrap (no SSH-in): you run the returned install command on the box.
+"""
 input AddServerInput {
   host: String!
   name: String!
-  sshPort: Int
-  sshUser: String
+}
+
+"""A newly registered server + its one-time agent install command."""
+type AddServerPayload {
+  """
+  Paste-on-the-server command to provision the agent. Shown once; embeds a single-use token.
+  """
+  installCommand: String
+  server: Server
 }
 
 """
@@ -502,6 +511,8 @@ type GithubRepo {
 """A registered user in the instance-wide Users list (no email exposed)."""
 type GlobalUser {
   avatarColor: String
+  canExposePorts: Boolean
+  canMountHostVolumes: Boolean
   createdAt: String
   isInstanceAdmin: Boolean
   name: String
@@ -567,13 +578,18 @@ type Mutation {
 
   """Add a registry credential to the active team. Returns true."""
   addRegistry(input: AddRegistryInput!): Boolean
-  addServer(input: AddServerInput!): Server
+  addServer(input: AddServerInput!): AddServerPayload
   cancelDeployment(id: String!): Boolean
 
   """
   Change the current user's password after verifying the current one. Returns true.
   """
   changePassword(currentPassword: String!, newPassword: String!): Boolean
+
+  """
+  Force an immediate re-resolution of the latest agent release from GitHub, bypassing the in-process cache. Returns the resolved expected agent version so the dashboard re-renders with fresh outdated badges. Use after publishing a new agent release rather than waiting out the cache TTL.
+  """
+  checkAgentUpdates: String
 
   """Re-run the upstream release check and return the latest update info."""
   checkForUpdates: UpdateInfo
@@ -663,6 +679,11 @@ type Mutation {
   """
   registerThroughLink(email: String!, name: String!, password: String!, teamName: String!, token: String!, username: String!): AuthPayload
 
+  """
+  Mint a fresh install command for a server still provisioning (the original token expired or was lost).
+  """
+  reissueServerBootstrap(id: String!): AddServerPayload
+
   """Remove a dev SSH user. Returns true."""
   removeDevSshUser(id: String!): Boolean
 
@@ -675,8 +696,10 @@ type Mutation {
   """Remove a member from the active team. Returns true."""
   removeMember(userId: String!): Boolean
 
-  """Disconnect and remove a remote server. Returns true."""
-  removeServer(id: String!): Boolean
+  """
+  Disconnect and remove a remote server (revokes trust, best-effort teardown). Returns a warning string if the agent was unreachable, else null.
+  """
+  removeServer(id: String!): String
   renameProject(id: String!, name: String!): Project
 
   """Rename or move a file/folder within the project files tree."""
@@ -684,6 +707,9 @@ type Mutation {
 
   """Render the docker-compose stack a project would deploy."""
   renderComposeStack(projectId: String!): String
+
+  """Set the team-wide display order of projects in Overview."""
+  reorderProjects(projectIds: [ID!]!): Boolean
 
   """DESTRUCTIVE: replace the workspace with a fresh copy of the source."""
   resetDevWorkspace(projectId: String!): DevInfo
@@ -718,6 +744,11 @@ type Mutation {
   """Make this domain its project's primary (canonical) host. Returns true."""
   setPrimaryDomain(id: String!): Boolean
   setProjectAutoDeploy(id: String!, value: Boolean!): Project
+
+  """
+  Replace a single-container project's volumes (named, project-files, and host bind mounts).
+  """
+  setProjectVolumes(id: String!, volumes: [VolumeInput!]!): Project
 
   """Attach or detach a shared group to one project. Returns true."""
   setSharedEnvGroupAttachment(attached: Boolean!, groupId: String!, projectId: String!): Boolean
@@ -779,6 +810,11 @@ type Mutation {
   updateProjectBuild(build: BuildConfigInput!, id: String!): Project
   updateProjectLogo(id: String!, logo: String): Project
   updateProjectSource(id: String!, input: UpdateSourceInput!): Project
+
+  """
+  Update this server's agent binary in place to the latest released version WITHOUT reissuing its certificates — the agent self-updates over its existing pinned-mTLS channel and re-execs keeping the same on-disk trust materials, so the server stays online with the same identity. Returns the version the agent is now running. Errors clearly when the server is unreachable/unprovisioned, or — until the agent ships the self-update RPC — when its agent is too old to update itself remotely (re-run the installer to upgrade it for now).
+  """
+  updateServerAgent(id: String!): String
   updateTeam(input: UpdateTeamInput!): Team
 
   """Edit a user's instance-admin flag, suspended state, and password."""
@@ -832,6 +868,9 @@ type Project {
   status: ProjectStatus
   teamId: ID
   updatedAt: String
+
+  """Persistent named volumes (single-container projects only)."""
+  volumes: [Volume!]
 }
 
 """One project together with all of its env vars."""
@@ -868,6 +907,7 @@ enum ProjectStatus {
   error
   idle
   queued
+  stopping
 }
 
 type Query {
@@ -955,7 +995,9 @@ type Query {
   """The active team's notification settings (defaults if unset)."""
   notificationSettings: NotificationSettings
 
-  """The master (localhost) server, or the first one available."""
+  """
+  The first server available, or null when none has been added/provisioned yet.
+  """
   primaryServer: Server
   project(slug: String!): Project
 
@@ -991,7 +1033,7 @@ type Query {
   """A fresh live metrics snapshot for one server."""
   serverMetrics(serverId: String!): ServerMetrics
 
-  """All servers, master first then remotes by creation order."""
+  """All servers, by creation order."""
   servers: [Server!]
 
   """All shared env groups in the active team, A→Z."""
@@ -1103,10 +1145,17 @@ input SaveSharedEnvGroupInput {
   targets: [EnvTarget!]!
 }
 
-"""A host (the master or a connected remote) running deployments."""
+"""A connected host running deployments (reached via its agent)."""
 type Server {
+  """
+  True when this server's reported agent version is strictly older than expectedAgentVersion. False for an unseen agent or a non-semver/dev version we can't confidently compare.
+  """
   agentOutdated: Boolean
   agentPort: Int
+
+  """
+  The agent binary version last reported by this server on its last Hello. Null until the server's agent has called home and been provisioned.
+  """
   agentVersion: String
   cpuCores: Int
   cpuUsage: Int
@@ -1114,14 +1163,22 @@ type Server {
   diskGb: Int
   diskUsage: Int
   dockerVersion: String
+
+  """
+  The agent version this server should be running — the latest GitHub release of the agent (DeploCloud/deplo-agent). Resolved at request time and cached; falls back to a built-in version when GitHub is unreachable.
+  """
   expectedAgentVersion: String
   host: String
   id: ID
   ip: String
+
+  """Heartbeat cache (P5) — a hint, not the source of truth."""
   lastSeenAt: String
   memoryMb: Int
   memoryUsage: Int
   name: String
+
+  """True once the server's agent has called home and been trusted."""
   provisioned: Boolean
   status: ServerStatus
   traefikEnabled: Boolean
@@ -1148,6 +1205,7 @@ type ServerMetrics {
   netTx: Float
   online: Boolean
   serverId: ID
+  traefik: Boolean
   ts: Float
   uptimeSec: Int
 }
@@ -1160,7 +1218,6 @@ enum ServerStatus {
 }
 
 enum ServerType {
-  localhost
   remote
 }
 
@@ -1197,6 +1254,13 @@ type SharedEnvVar {
 input ShellLabelInput {
   containerName: String
   projectId: String!
+}
+
+type Subscription {
+  """
+  Emits the project whenever its status (power / deployment) changes. Fires once immediately with the current snapshot, then on every change.
+  """
+  projectStatus(slug: String!): Project
 }
 
 """A team that owns projects, infra and members."""
@@ -1275,6 +1339,8 @@ input UpdateTeamInput {
 }
 
 input UpdateUserAdminInput {
+  canExposePorts: Boolean
+  canMountHostVolumes: Boolean
   isInstanceAdmin: Boolean!
   newPassword: String
   suspended: Boolean!
@@ -1299,6 +1365,8 @@ Full per-user detail for the admin editor — the email IS included here.
 """
 type UserDetail {
   avatarColor: String
+  canExposePorts: Boolean
+  canMountHostVolumes: Boolean
   createdAt: String
   email: String
   isInstanceAdmin: Boolean
@@ -1336,6 +1404,30 @@ type Viewer {
   name: String
   role: String
   username: String
+}
+
+"""
+A persistent volume mounted into a single-container project — a docker named volume, a project-files bind, or a host bind mount.
+"""
+type Volume {
+  hostPath: String
+  id: ID
+  mountPath: String
+  name: String
+  projectPath: String
+  readOnly: Boolean
+  type: String
+}
+
+"""A persistent volume for a single-container project."""
+input VolumeInput {
+  hostPath: String
+  id: String
+  mountPath: String!
+  name: String
+  projectPath: String
+  readOnly: Boolean
+  type: String
 }
 
 """VS Code Remote Tunnel status for a project's dev container."""


### PR DESCRIPTION
…ved)

Wire the dashboard 'Update agent' action to the agent's new SelfUpdate RPC: the control plane resolves the latest release, dials the agent over its existing pinned-mTLS channel, and sends every per-arch binary (url + sha256); the agent picks its own arch, verifies, swaps its binary, and re-execs reusing the on-disk mTLS materials — so the server keeps its identity + pinned fingerprint, no re-bootstrap, no token. Certs are never reissued.

- agent-client: real selfUpdateServerAgent (was a stub) + a selfUpdate connection method; gates on the agent's 'self-update' capability and maps UNIMPLEMENTED to a clear 'too old — re-run the installer' message.
- data/servers: updateServerAgent resolves nothing itself now; the seam owns the one-consistent-release resolution.
- regenerated TS stubs from the agent proto (SelfUpdate + ArchBinary).
- UI: 'Update agent to vX' menu item (shown when outdated) + confirm dialog.

Verified end-to-end against a live agent: version flips OLD->NEW, binary swaps, agent re-execs in place, mTLS materials untouched.