### PR TITLE
feat(store): relational-store Step 2 — leaf cut-set (a) async data layer

### DIFF
--- a/lib/data/apps.test.ts
+++ b/lib/data/apps.test.ts
@@ -1,0 +1,86 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { PGlite } from "@electric-sql/pglite";
+
+import { makeTestDb, type TestDb } from "../db/test-harness";
+import { __setTestDb, __resetTestDb } from "../db/client";
+import { installedApps as installedAppsTable } from "../db/schema/control-plane";
+import { runWithIdentity } from "../auth/request-context";
+import { seedIdentity, TEAM_A, TEAM_B, USER_1 } from "./leaf-test-helpers";
+import { appRuntimeStatus, startApp, stopApp } from "./apps";
+
+/**
+ * Data-layer tests for `installed_apps` against pglite (PLAN Step 2). These
+ * exercise the async Drizzle READ + team-scoping path. The install/uninstall
+ * mutations and `listInstalledApps` go through the app runtime (Docker) and
+ * `headers()` (a request scope) so they aren't unit-testable here — that was true
+ * of the JSONB version too. The migration-relevant change (the team-scoped
+ * `findApp` query + the "App not installed" guard) is fully covered:
+ *  - `appRuntimeStatus` resolves an existing row (status "error" — no Docker — is
+ *    the honest answer when the daemon is unreachable),
+ *  - `startApp`/`stopApp` reject a row that isn't in the caller's active team
+ *    BEFORE touching the runtime (the team-scoped find returns null).
+ */
+
+let db: TestDb;
+let pg: PGlite;
+
+before(async () => {
+  ({ db, pg } = await makeTestDb());
+  __setTestDb(db);
+});
+
+after(async () => {
+  __resetTestDb();
+  await pg.close();
+});
+
+beforeEach(async () => {
+  await pg.exec(
+    `truncate table installed_apps, users, teams restart identity cascade;`,
+  );
+  await seedIdentity(db, {
+    users: [
+      { id: USER_1, teamId: TEAM_A, role: "owner" },
+      { id: "user_2", teamId: TEAM_B, role: "owner" },
+    ],
+  });
+});
+
+const asUser1 = <T>(fn: () => Promise<T>): Promise<T> =>
+  runWithIdentity({ userId: USER_1, teamId: TEAM_A }, fn);
+
+async function seedApp(id: string, teamId: string, slug: string): Promise<void> {
+  await db.insert(installedAppsTable).values({
+    id,
+    teamId,
+    catalogId: "mcp",
+    slug,
+    version: "1.0.0",
+    createdAt: "2026-02-01T00:00:00.000Z",
+  });
+}
+
+test("appRuntimeStatus reads an existing app in the active team (error without Docker)", async () => {
+  await seedApp("app_1", TEAM_A, "mcp__alpha");
+  await asUser1(async () => {
+    assert.equal(await appRuntimeStatus("app_1"), "error");
+  });
+});
+
+test("appRuntimeStatus rejects an app the active team does not own", async () => {
+  await seedApp("app_b", TEAM_B, "mcp__beta");
+  await asUser1(async () => {
+    await assert.rejects(() => appRuntimeStatus("app_b"), /App not installed/);
+  });
+});
+
+test("startApp / stopApp reject a cross-team app before touching the runtime", async () => {
+  await seedApp("app_b", TEAM_B, "mcp__beta");
+  await asUser1(async () => {
+    // Team-scoped find returns null → "App not installed" before any docker call.
+    await assert.rejects(() => startApp("app_b"), /App not installed/);
+    await assert.rejects(() => stopApp("app_b"), /App not installed/);
+  });
+});

--- a/lib/data/apps.ts
+++ b/lib/data/apps.ts
@@ -1,7 +1,11 @@
 import "server-only";
 
 import { headers } from "next/headers";
-import { read, mutate } from "../store";
+import { and, desc, eq } from "drizzle-orm";
+
+import { read } from "../store";
+import { getDb } from "../db/client";
+import { installedApps as installedAppsTable } from "../db/schema/control-plane";
 import { newId, nowIso } from "../ids";
 import { requireActiveTeamId, requireCapability } from "../membership";
 import { recordActivity } from "./activity";
@@ -42,12 +46,15 @@ export interface InstalledAppDTO {
   createdAt: string;
 }
 
-function installedApps(): InstalledApp[] {
-  return read().installedApps ?? [];
-}
+/** The stored fields of an installed app — a `installed_apps` row. */
+type AppRow = Pick<
+  InstalledApp,
+  "id" | "teamId" | "catalogId" | "slug" | "version" | "createdAt"
+>;
 
 /** Resolve a team's slug — seeds the deterministic app slug at INSTALL time. */
 function teamSlug(teamId: string): string {
+  // Team slugs live in the JSONB teams collection (cut-set b — authoritative this step).
   const team = read().teams.find((t) => t.id === teamId);
   if (!team) throw new Error("Active team not found");
   return team.slug;
@@ -58,8 +65,18 @@ function teamSlug(teamId: string): string {
  * deriving it for legacy rows written before `slug` was stored (the team has
  * not been renamed yet, so the derived value still matches the live container).
  */
-function appSlugFor(app: InstalledApp): string {
+function appSlugFor(app: AppRow): string {
   return app.slug || appSlug(app.catalogId, teamSlug(app.teamId));
+}
+
+/** Fetch one installed-app row scoped to the active team, or null. */
+async function findApp(id: string, teamId: string): Promise<AppRow | null> {
+  const rows = await getDb()
+    .select()
+    .from(installedAppsTable)
+    .where(and(eq(installedAppsTable.id, id), eq(installedAppsTable.teamId, teamId)))
+    .limit(1);
+  return rows[0] ?? null;
 }
 
 /** Deplo's public base URL, preferring DEPLO_PUBLIC_URL, else the request host. */
@@ -67,7 +84,7 @@ async function publicBaseUrl(): Promise<string> {
   return resolvePublicBaseUrl(await headers());
 }
 
-async function toDTO(app: InstalledApp): Promise<InstalledAppDTO> {
+async function toDTO(app: AppRow): Promise<InstalledAppDTO> {
   const slug = appSlugFor(app);
   const base = await publicBaseUrl();
   return {
@@ -92,9 +109,11 @@ export async function getAppCatalog(): Promise<AppListing[]> {
 /** All apps the active team has installed, newest first, with live status. */
 export async function listInstalledApps(): Promise<InstalledAppDTO[]> {
   const teamId = await requireActiveTeamId();
-  const rows = installedApps()
-    .filter((a) => a.teamId === teamId)
-    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  const rows = await getDb()
+    .select()
+    .from(installedAppsTable)
+    .where(eq(installedAppsTable.teamId, teamId))
+    .orderBy(desc(installedAppsTable.createdAt));
   return Promise.all(rows.map(toDTO));
 }
 
@@ -103,7 +122,7 @@ export async function appRuntimeStatus(
   id: string,
 ): Promise<"running" | "stopped" | "error"> {
   const teamId = await requireActiveTeamId();
-  const app = installedApps().find((a) => a.id === id && a.teamId === teamId);
+  const app = await findApp(id, teamId);
   if (!app) throw new Error("App not installed");
   return appStatus(appSlugFor(app));
 }
@@ -153,9 +172,18 @@ export async function installApp(catalogId: string): Promise<InstalledAppDTO> {
   // create a fresh one. The slug is FROZEN — reuse the existing row's slug so a
   // reinstall after a team rename still targets the original container; only a
   // brand-new install derives the slug from the current team slug.
-  const existing = installedApps().find(
-    (a) => a.teamId === teamId && a.catalogId === catalogId,
-  );
+  const existing = (
+    await getDb()
+      .select()
+      .from(installedAppsTable)
+      .where(
+        and(
+          eq(installedAppsTable.teamId, teamId),
+          eq(installedAppsTable.catalogId, catalogId),
+        ),
+      )
+      .limit(1)
+  )[0];
   const slug = existing ? appSlugFor(existing) : appSlug(catalogId, teamSlug(teamId));
   await startAppStack({
     slug,
@@ -165,14 +193,13 @@ export async function installApp(catalogId: string): Promise<InstalledAppDTO> {
     isReinstall: !!existing,
   });
 
-  let row: InstalledApp;
+  let row: AppRow;
   if (existing) {
     row = { ...existing, slug, version: manifest.version };
-    mutate((d) => {
-      d.installedApps = (d.installedApps ?? []).map((a) =>
-        a.id === existing.id ? row : a,
-      );
-    });
+    await getDb()
+      .update(installedAppsTable)
+      .set({ slug, version: manifest.version })
+      .where(eq(installedAppsTable.id, existing.id));
   } else {
     row = {
       id: newId("app"),
@@ -182,10 +209,7 @@ export async function installApp(catalogId: string): Promise<InstalledAppDTO> {
       version: manifest.version,
       createdAt: nowIso(),
     };
-    mutate((d) => {
-      d.installedApps ??= [];
-      d.installedApps.push(row);
-    });
+    await getDb().insert(installedAppsTable).values(row);
   }
   recordActivity(
     "member",
@@ -206,13 +230,13 @@ export async function uninstallApp(id: string): Promise<void> {
   const { membership } = await requireCapability("manage_infra");
   const user = read().users.find((u) => u.id === membership.userId)!;
   const teamId = membership.teamId;
-  const app = installedApps().find((a) => a.id === id && a.teamId === teamId);
+  const app = await findApp(id, teamId);
   if (!app) throw new Error("App not installed");
 
   await destroyAppContainer(appSlugFor(app));
-  mutate((d) => {
-    d.installedApps = (d.installedApps ?? []).filter((a) => a.id !== id);
-  });
+  await getDb()
+    .delete(installedAppsTable)
+    .where(and(eq(installedAppsTable.id, id), eq(installedAppsTable.teamId, teamId)));
   recordActivity(
     "member",
     `Uninstalled app ${app.catalogId}`,
@@ -225,8 +249,7 @@ export async function uninstallApp(id: string): Promise<void> {
 /** Start a stopped app's container (`manage_infra`). */
 export async function startApp(id: string): Promise<void> {
   const { membership } = await requireCapability("manage_infra");
-  const teamId = membership.teamId;
-  const app = installedApps().find((a) => a.id === id && a.teamId === teamId);
+  const app = await findApp(id, membership.teamId);
   if (!app) throw new Error("App not installed");
   await startAppContainer(appSlugFor(app));
 }
@@ -234,8 +257,7 @@ export async function startApp(id: string): Promise<void> {
 /** Stop a running app's container (`manage_infra`). */
 export async function stopApp(id: string): Promise<void> {
   const { membership } = await requireCapability("manage_infra");
-  const teamId = membership.teamId;
-  const app = installedApps().find((a) => a.id === id && a.teamId === teamId);
+  const app = await findApp(id, membership.teamId);
   if (!app) throw new Error("App not installed");
   await stopAppContainer(appSlugFor(app));
 }

--- a/lib/data/leaf-backfill-read.test.ts
+++ b/lib/data/leaf-backfill-read.test.ts
@@ -1,0 +1,133 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { PGlite } from "@electric-sql/pglite";
+
+import { buildSeed } from "../seed";
+import {
+  defaultNotificationSettings,
+  type DeploData,
+  type NotificationSettings,
+} from "../types";
+import { makeTestDb, type TestDb } from "../db/test-harness";
+import { __setTestDb, __resetTestDb } from "../db/client";
+import { runBackfill } from "../db/backfill/engine";
+import { leafCutSetCopy } from "../db/backfill/cut-sets/leaf";
+import { CUT_SETS } from "../db/backfill/markers";
+import { runWithIdentity } from "../auth/request-context";
+import { capabilitiesForRole } from "../membership-shared";
+import * as store from "../store";
+import { listTokens } from "./tokens";
+import { listRegistries } from "./registries";
+import { getNotificationSettings } from "./notifications";
+
+/**
+ * End-to-end: the leaf BACKFILL (copy from a live JSONB doc into the relational
+ * tables) and the new async DATA LAYER agree (relational-store PLAN Step 2
+ * "backfill fidelity"). We seed a `DeploData`, run the leaf cut-set's backfill
+ * against pglite, then read it back through the LIVE data functions — proving the
+ * copy lands in exactly the rows/shape the async reads expect.
+ */
+
+let db: TestDb;
+let pg: PGlite;
+
+before(async () => {
+  ({ db, pg } = await makeTestDb());
+  __setTestDb(db);
+});
+
+after(async () => {
+  __resetTestDb();
+  await pg.close();
+});
+
+beforeEach(async () => {
+  await pg.exec(`
+    truncate table api_tokens, registries, installed_apps,
+      notification_settings, store_migration, users, teams restart identity cascade;
+  `);
+});
+
+const TEAM = "team_a";
+const USER = "user_1";
+const T0 = "2026-01-01T00:00:00.000Z";
+
+function customSettings(): NotificationSettings {
+  const s = defaultNotificationSettings();
+  return {
+    channels: {
+      push: { enabled: true },
+      email: { enabled: true, address: "alerts@alpha.io" },
+      discord: { enabled: false, webhookUrl: "" },
+      webhook: { enabled: true, url: "https://hook.alpha.io" },
+    },
+    events: { ...s.events, deployment_succeeded: true },
+  };
+}
+
+/** A JSONB doc the backfill will copy from. */
+function doc(): DeploData {
+  const d = buildSeed();
+  d.teams = [{ id: TEAM, name: "Alpha", slug: "alpha", plan: "pro", createdAt: T0 }];
+  d.users = [
+    {
+      id: USER, email: "owner@alpha.io", username: "owner", name: "Owner",
+      passwordHash: "h", role: "owner", isInstanceAdmin: true,
+      avatarColor: "#abc", createdAt: T0,
+    },
+  ];
+  d.memberships = [
+    {
+      id: "mem_1", userId: USER, teamId: TEAM, role: "owner",
+      capabilities: capabilitiesForRole("owner"), createdAt: T0,
+    },
+  ];
+  d.apiTokens = [
+    {
+      id: "tok_1", teamId: TEAM, userId: USER, name: "CI",
+      tokenHash: "hash_ci", prefix: "deplo_ci", lastUsedAt: null, createdAt: "2026-02-01T00:00:00.000Z",
+    },
+  ];
+  d.registries = [
+    {
+      id: "reg_1", teamId: TEAM, name: "GHCR", type: "ghcr",
+      registryUrl: "ghcr.io", username: "alpha", passwordEnc: "enc_pw",
+      createdAt: "2026-02-02T00:00:00.000Z",
+    },
+  ];
+  d.notificationSettings = { [TEAM]: customSettings() };
+  return d;
+}
+
+test("leaf backfill → async data layer reads back the copied rows", async () => {
+  const d = doc();
+
+  // 1) Run the cut-set's backfill (copy from the JSONB doc into pglite).
+  await runBackfill(db, CUT_SETS.leaf, d, leafCutSetCopy);
+
+  // 2) Mirror identity into the JSONB store so requireActiveTeamId resolves
+  //    (identity is still JSONB this step; the leaf collections are now in pglite).
+  store.reseed();
+  store.mutate((s) => {
+    s.teams = d.teams;
+    s.users = d.users;
+    s.memberships = d.memberships;
+  });
+
+  // 3) Read each leaf collection through the LIVE async data functions.
+  await runWithIdentity({ userId: USER, teamId: TEAM }, async () => {
+    const tokens = await listTokens();
+    assert.equal(tokens.length, 1);
+    assert.equal(tokens[0]!.id, "tok_1");
+    assert.equal(tokens[0]!.name, "CI");
+
+    const regs = await listRegistries();
+    assert.equal(regs.length, 1);
+    assert.equal(regs[0]!.name, "GHCR");
+    assert.equal("passwordEnc" in regs[0]!, false);
+
+    const settings = await getNotificationSettings();
+    assert.deepEqual(settings, customSettings());
+  });
+});

--- a/lib/data/leaf-test-helpers.ts
+++ b/lib/data/leaf-test-helpers.ts
@@ -1,0 +1,118 @@
+import { teams, users } from "../db/schema/control-plane";
+import { capabilitiesForRole } from "../membership-shared";
+import type { TestDb } from "../db/test-harness";
+import type { Role } from "../types";
+import * as store from "../store";
+
+/**
+ * Shared seeding for the leaf cut-set data-layer tests (relational-store PLAN
+ * Step 2). In Step 2 only the four leaf collections live in Postgres; identity
+ * (`users`/`teams`/`memberships`) is still the JSONB store (cut-set b). So a test
+ * that drives a `requireCapability`-gated leaf function must seed BOTH:
+ *
+ *  - the JSONB store with a user + team + membership (so `requireActiveTeamId` /
+ *    `requireCapability` resolve — these still read `read()`), and
+ *  - the pglite FK roots `teams`/`users` (so the leaf rows' NOT-NULL
+ *    `team_id`/`user_id` FKs resolve).
+ *
+ * The caller drives the data functions inside `runWithIdentity({userId, teamId})`
+ * so the cookie-free principal/team is visible without a request scope.
+ *
+ * Not named `*.test.ts` so the `node --test` glob skips it (a helper, like
+ * `test-harness.ts`).
+ */
+
+export const TEAM_A = "team_a";
+export const TEAM_B = "team_b";
+export const USER_1 = "user_1";
+
+const T0 = "2026-01-01T00:00:00.000Z";
+
+interface SeedTeam {
+  id: string;
+  slug: string;
+}
+interface SeedUser {
+  id: string;
+  teamId: string;
+  role?: Role;
+}
+
+const DEFAULT_TEAMS: SeedTeam[] = [
+  { id: TEAM_A, slug: "alpha" },
+  { id: TEAM_B, slug: "beta" },
+];
+const DEFAULT_USERS: SeedUser[] = [{ id: USER_1, teamId: TEAM_A, role: "owner" }];
+
+/**
+ * Seed identity into BOTH the JSONB store and the pglite FK roots. Defaults to
+ * two teams (alpha/beta) and one owner user in alpha — enough for "owner can
+ * mutate" + "cross-team isolation" assertions. Call in `beforeEach` AFTER
+ * truncating and AFTER `store.reseed()`.
+ */
+export async function seedIdentity(
+  db: TestDb,
+  opts: { teams?: SeedTeam[]; users?: SeedUser[] } = {},
+): Promise<void> {
+  const seedTeams = opts.teams ?? DEFAULT_TEAMS;
+  const seedUsers = opts.users ?? DEFAULT_USERS;
+
+  store.reseed();
+  store.mutate((d) => {
+    for (const t of seedTeams) {
+      d.teams.push({
+        id: t.id,
+        name: t.slug,
+        slug: t.slug,
+        plan: "pro",
+        createdAt: T0,
+      });
+    }
+    for (const u of seedUsers) {
+      const role = u.role ?? "owner";
+      d.users.push({
+        id: u.id,
+        email: `${u.id}@example.io`,
+        username: u.id,
+        name: u.id,
+        passwordHash: "h",
+        role,
+        isInstanceAdmin: role === "owner",
+        avatarColor: "#abc",
+        createdAt: T0,
+      });
+      d.memberships.push({
+        id: `mem_${u.id}`,
+        userId: u.id,
+        teamId: u.teamId,
+        role,
+        capabilities: capabilitiesForRole(role),
+        createdAt: T0,
+      });
+    }
+  });
+
+  // FK roots in pglite.
+  await db.insert(teams).values(
+    seedTeams.map((t) => ({
+      id: t.id,
+      name: t.slug,
+      slug: t.slug,
+      plan: "pro" as const,
+      createdAt: T0,
+    })),
+  );
+  await db.insert(users).values(
+    seedUsers.map((u) => ({
+      id: u.id,
+      email: `${u.id}@example.io`,
+      username: u.id,
+      name: u.id,
+      passwordHash: "h",
+      role: u.role ?? "owner",
+      isInstanceAdmin: (u.role ?? "owner") === "owner",
+      avatarColor: "#abc",
+      createdAt: T0,
+    })),
+  );
+}

--- a/lib/data/notification-row.ts
+++ b/lib/data/notification-row.ts
@@ -1,0 +1,74 @@
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+
+import { notificationSettings } from "../db/schema/control-plane";
+import type { NotificationEvent, NotificationSettings } from "../types";
+
+/**
+ * The ONE flat-columns ↔ nested-object mapping for `notification_settings`
+ * (relational-store PLAN §2 "notification_settings"), shared by the backfill
+ * cut-set (`lib/db/backfill/cut-sets/leaf.ts`) and the live data layer
+ * (`lib/data/notifications.ts`) so the two can't drift. Pure — no `server-only`,
+ * no store, no db handle — so both a `server-only` module and a backfill helper
+ * can import it.
+ *
+ * The relational table flattens the `{channels, events}` object into one boolean/
+ * text column per field (no JSONB map). `settingsToRow` explodes the object into
+ * columns; `rowToSettings` reassembles it. The `EVENT_COLUMNS` table below is
+ * declared `satisfies Record<NotificationEvent, …>`, so adding a new event to the
+ * union fails to compile until it is mapped here — a settings event can never be
+ * silently dropped on either path (PLAN §7 "exhaustive … coverage").
+ */
+
+type NotificationRow = InferSelectModel<typeof notificationSettings>;
+type NotificationInsert = InferInsertModel<typeof notificationSettings>;
+
+/**
+ * Each {@link NotificationEvent} ↔ its flat column name. The single source of
+ * truth for the event mapping, exhaustiveness-checked at compile time.
+ */
+const EVENT_COLUMNS = {
+  deployment_failed: "deploymentFailed",
+  deployment_succeeded: "deploymentSucceeded",
+  server_offline: "serverOffline",
+  high_resource_usage: "highResourceUsage",
+  update_available: "updateAvailable",
+} as const satisfies Record<NotificationEvent, keyof NotificationRow>;
+
+/** Explode a {@link NotificationSettings} into its flat `notification_settings` row. */
+export function settingsToRow(
+  teamId: string,
+  s: NotificationSettings,
+): NotificationInsert {
+  return {
+    teamId,
+    pushEnabled: s.channels.push.enabled,
+    emailEnabled: s.channels.email.enabled,
+    emailAddress: s.channels.email.address,
+    discordEnabled: s.channels.discord.enabled,
+    discordWebhookUrl: s.channels.discord.webhookUrl,
+    webhookEnabled: s.channels.webhook.enabled,
+    webhookUrl: s.channels.webhook.url,
+    deploymentFailed: s.events.deployment_failed,
+    deploymentSucceeded: s.events.deployment_succeeded,
+    serverOffline: s.events.server_offline,
+    highResourceUsage: s.events.high_resource_usage,
+    updateAvailable: s.events.update_available,
+  };
+}
+
+/** Reassemble a flat `notification_settings` row into a {@link NotificationSettings}. */
+export function rowToSettings(row: NotificationRow): NotificationSettings {
+  const events = {} as Record<NotificationEvent, boolean>;
+  for (const event of Object.keys(EVENT_COLUMNS) as NotificationEvent[]) {
+    events[event] = row[EVENT_COLUMNS[event]];
+  }
+  return {
+    channels: {
+      push: { enabled: row.pushEnabled },
+      email: { enabled: row.emailEnabled, address: row.emailAddress },
+      discord: { enabled: row.discordEnabled, webhookUrl: row.discordWebhookUrl },
+      webhook: { enabled: row.webhookEnabled, url: row.webhookUrl },
+    },
+    events,
+  };
+}

--- a/lib/data/notifications.test.ts
+++ b/lib/data/notifications.test.ts
@@ -1,0 +1,87 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { PGlite } from "@electric-sql/pglite";
+
+import { makeTestDb, type TestDb } from "../db/test-harness";
+import { __setTestDb, __resetTestDb } from "../db/client";
+import { notificationSettings } from "../db/schema/control-plane";
+import { runWithIdentity } from "../auth/request-context";
+import { defaultNotificationSettings, type NotificationSettings } from "../types";
+import { seedIdentity, TEAM_A, USER_1 } from "./leaf-test-helpers";
+import {
+  getNotificationSettings,
+  updateNotificationSettings,
+} from "./notifications";
+
+/**
+ * Data-layer tests for `notification_settings` against pglite (PLAN Step 2). The
+ * collection is a `Record<teamId, …>` map → one row per team; an absent row reads
+ * back as `defaultNotificationSettings()`. `updateNotificationSettings` upserts on
+ * the `team_id` PK so a second save overwrites rather than duplicating.
+ */
+
+let db: TestDb;
+let pg: PGlite;
+
+before(async () => {
+  ({ db, pg } = await makeTestDb());
+  __setTestDb(db);
+});
+
+after(async () => {
+  __resetTestDb();
+  await pg.close();
+});
+
+beforeEach(async () => {
+  await pg.exec(
+    `truncate table notification_settings, users, teams restart identity cascade;`,
+  );
+  await seedIdentity(db);
+});
+
+const asUser1 = <T>(fn: () => Promise<T>): Promise<T> =>
+  runWithIdentity({ userId: USER_1, teamId: TEAM_A }, fn);
+
+function customSettings(): NotificationSettings {
+  const s = defaultNotificationSettings();
+  return {
+    channels: {
+      push: { enabled: true },
+      email: { enabled: true, address: "alerts@alpha.io" },
+      discord: { enabled: true, webhookUrl: "https://discord/hook" },
+      webhook: { enabled: false, url: "" },
+    },
+    events: { ...s.events, deployment_succeeded: true, update_available: false },
+  };
+}
+
+test("getNotificationSettings returns the default when the team has no row", async () => {
+  await asUser1(async () => {
+    assert.deepEqual(await getNotificationSettings(), defaultNotificationSettings());
+  });
+  assert.equal((await db.select().from(notificationSettings)).length, 0);
+});
+
+test("update then get round-trips every channel and event", async () => {
+  const next = customSettings();
+  await asUser1(async () => {
+    const returned = await updateNotificationSettings(next);
+    assert.deepEqual(returned, next);
+    assert.deepEqual(await getNotificationSettings(), next);
+  });
+});
+
+test("a second update overwrites the same row (upsert, no duplicate)", async () => {
+  await asUser1(async () => {
+    await updateNotificationSettings(customSettings());
+    const changed = customSettings();
+    changed.channels.email.address = "changed@alpha.io";
+    await updateNotificationSettings(changed);
+    const got = await getNotificationSettings();
+    assert.equal(got.channels.email.address, "changed@alpha.io");
+  });
+  // Exactly one row for the team (team_id PK).
+  assert.equal((await db.select().from(notificationSettings)).length, 1);
+});

--- a/lib/data/notifications.ts
+++ b/lib/data/notifications.ts
@@ -1,17 +1,32 @@
 import "server-only";
 
-import { read, mutate } from "../store";
+import { eq } from "drizzle-orm";
+
+import { getDb } from "../db/client";
+import { notificationSettings } from "../db/schema/control-plane";
 import { requireActiveTeamId, requireCapability } from "../membership";
 import { defaultNotificationSettings } from "../types";
+import { rowToSettings, settingsToRow } from "./notification-row";
 import type { NotificationChannel, NotificationSettings } from "../types";
 
 /** Default config, also used to backfill stores seeded before this feature. */
 export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings =
   defaultNotificationSettings();
 
+/** The active team's row, or `null` when it has none (read falls back to default). */
+async function settingsRowFor(teamId: string): Promise<NotificationSettings | null> {
+  const rows = await getDb()
+    .select()
+    .from(notificationSettings)
+    .where(eq(notificationSettings.teamId, teamId))
+    .limit(1);
+  return rows[0] ? rowToSettings(rows[0]) : null;
+}
+
 export async function getNotificationSettings(): Promise<NotificationSettings> {
   const teamId = await requireActiveTeamId();
-  return read().notificationSettings[teamId] ?? defaultNotificationSettings();
+  // Absent row = never configured → the default (PLAN §2 "Missing row = default").
+  return (await settingsRowFor(teamId)) ?? defaultNotificationSettings();
 }
 
 export async function updateNotificationSettings(
@@ -19,10 +34,14 @@ export async function updateNotificationSettings(
 ): Promise<NotificationSettings> {
   // Notifications are an infra-level team setting.
   const teamId = (await requireCapability("manage_infra")).teamId;
-  return mutate((d) => {
-    d.notificationSettings[teamId] = next;
-    return d.notificationSettings[teamId];
-  });
+  const row = settingsToRow(teamId, next);
+  // One row per team (team_id PK): upsert so the first save inserts and later
+  // saves overwrite — never a duplicate row.
+  await getDb()
+    .insert(notificationSettings)
+    .values(row)
+    .onConflictDoUpdate({ target: notificationSettings.teamId, set: row });
+  return next;
 }
 
 /**
@@ -39,7 +58,7 @@ export async function sendTestNotification(
   // to the team's configured Discord/webhook endpoints.
   const teamId = (await requireCapability("manage_infra")).teamId;
   const c =
-    read().notificationSettings[teamId]?.channels ??
+    (await settingsRowFor(teamId))?.channels ??
     DEFAULT_NOTIFICATION_SETTINGS.channels;
 
   const title = "Deplo test alert";

--- a/lib/data/registries.test.ts
+++ b/lib/data/registries.test.ts
@@ -1,0 +1,105 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { PGlite } from "@electric-sql/pglite";
+
+import { makeTestDb, type TestDb } from "../db/test-harness";
+import { __setTestDb, __resetTestDb } from "../db/client";
+import { registries as registriesTable } from "../db/schema/control-plane";
+import { decryptSecret } from "../crypto";
+import { runWithIdentity } from "../auth/request-context";
+import { seedIdentity, TEAM_A, TEAM_B, USER_1 } from "./leaf-test-helpers";
+import { addRegistry, deleteRegistry, listRegistries } from "./registries";
+
+/**
+ * Data-layer tests for `registries` against pglite (PLAN Step 2). Verifies the
+ * newest-first SQL sort, that the password is stored encrypted and never in the
+ * DTO, and that delete is team-scoped.
+ */
+
+let db: TestDb;
+let pg: PGlite;
+
+before(async () => {
+  ({ db, pg } = await makeTestDb());
+  __setTestDb(db);
+});
+
+after(async () => {
+  __resetTestDb();
+  await pg.close();
+});
+
+beforeEach(async () => {
+  await pg.exec(`truncate table registries, users, teams restart identity cascade;`);
+  // Two owners: user_1 in alpha, user_2 in beta (for the cross-team delete check).
+  await seedIdentity(db, {
+    users: [
+      { id: USER_1, teamId: TEAM_A, role: "owner" },
+      { id: "user_2", teamId: TEAM_B, role: "owner" },
+    ],
+  });
+});
+
+const asUser1 = <T>(fn: () => Promise<T>): Promise<T> =>
+  runWithIdentity({ userId: USER_1, teamId: TEAM_A }, fn);
+
+test("addRegistry stores an encrypted password; the DTO carries no secret", async () => {
+  await asUser1(async () => {
+    await addRegistry({
+      name: "GHCR",
+      type: "ghcr",
+      username: "alpha",
+      password: "s3cret",
+    });
+    const list = await listRegistries();
+    assert.equal(list.length, 1);
+    assert.equal(list[0]!.registryUrl, "ghcr.io", "default host for ghcr");
+    assert.equal("passwordEnc" in list[0]!, false, "no secret in the DTO");
+  });
+
+  const rows = await db.select().from(registriesTable);
+  assert.notEqual(rows[0]!.passwordEnc, "s3cret", "stored encrypted, not plaintext");
+  assert.equal(decryptSecret(rows[0]!.passwordEnc), "s3cret", "decrypts back to plaintext");
+});
+
+test("listRegistries returns newest-first", async () => {
+  await asUser1(async () => {
+    await addRegistry({ name: "first", type: "ghcr", username: "u", password: "p" });
+    await new Promise((r) => setTimeout(r, 5));
+    await addRegistry({ name: "second", type: "dockerhub", username: "u", password: "p" });
+    const list = await listRegistries();
+    assert.deepEqual(list.map((r) => r.name), ["second", "first"]);
+  });
+});
+
+test("addRegistry validates required fields", async () => {
+  await asUser1(async () => {
+    await assert.rejects(
+      () => addRegistry({ name: "", type: "ghcr", username: "u", password: "p" }),
+      /Enter a name/,
+    );
+    await assert.rejects(
+      () => addRegistry({ name: "x", type: "generic", username: "u", password: "p" }),
+      /Enter the registry host/,
+    );
+  });
+});
+
+test("deleteRegistry removes only the active team's matching registry", async () => {
+  // user_2 (team B) adds one; user_1 (team A) must not be able to delete it.
+  await runWithIdentity({ userId: "user_2", teamId: TEAM_B }, async () => {
+    await addRegistry({ name: "B-reg", type: "ghcr", username: "u", password: "p" });
+  });
+  const bRow = (await db.select().from(registriesTable))[0]!;
+
+  await asUser1(async () => {
+    await assert.rejects(() => deleteRegistry(bRow.id), /Registry not found/);
+  });
+  assert.equal((await db.select().from(registriesTable)).length, 1, "team-B row survives");
+
+  await runWithIdentity({ userId: "user_2", teamId: TEAM_B }, async () => {
+    await deleteRegistry(bRow.id);
+  });
+  assert.equal((await db.select().from(registriesTable)).length, 0);
+});

--- a/lib/data/registries.ts
+++ b/lib/data/registries.ts
@@ -1,11 +1,15 @@
 import "server-only";
 
-import { read, mutate } from "../store";
+import { and, desc, eq } from "drizzle-orm";
+
+import { read } from "../store";
+import { getDb } from "../db/client";
+import { registries as registriesTable } from "../db/schema/control-plane";
 import { newId, nowIso } from "../ids";
 import { requireActiveTeamId, requireCapability } from "../membership";
 import { recordActivity } from "./activity";
 import { encryptSecret } from "../crypto";
-import type { Registry, RegistryType } from "../types";
+import type { RegistryType } from "../types";
 
 export interface RegistryDTO {
   id: string;
@@ -24,27 +28,24 @@ export const REGISTRY_HOSTS: Record<RegistryType, string> = {
   generic: "",
 };
 
-function registries(): Registry[] {
-  return read().registries ?? [];
-}
-
-function toDTO(r: Registry): RegistryDTO {
-  return {
-    id: r.id,
-    name: r.name,
-    type: r.type,
-    registryUrl: r.registryUrl,
-    username: r.username,
-    createdAt: r.createdAt,
-  };
-}
+/** The non-secret projection — never selects `password_enc`. */
+const DTO_COLUMNS = {
+  id: registriesTable.id,
+  name: registriesTable.name,
+  type: registriesTable.type,
+  registryUrl: registriesTable.registryUrl,
+  username: registriesTable.username,
+  createdAt: registriesTable.createdAt,
+} as const;
 
 export async function listRegistries(): Promise<RegistryDTO[]> {
   const teamId = await requireActiveTeamId();
-  return registries()
-    .filter((r) => r.teamId === teamId)
-    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
-    .map(toDTO);
+  // Newest-first sort pushed into SQL (matches registries_team_created_idx).
+  return getDb()
+    .select(DTO_COLUMNS)
+    .from(registriesTable)
+    .where(eq(registriesTable.teamId, teamId))
+    .orderBy(desc(registriesTable.createdAt)) as Promise<RegistryDTO[]>;
 }
 
 export async function addRegistry(input: {
@@ -55,6 +56,8 @@ export async function addRegistry(input: {
   password: string;
 }): Promise<void> {
   const { membership } = await requireCapability("manage_infra");
+  // The actor's display name for the activity log lives in the JSONB users
+  // collection (cut-set b — still authoritative this step).
   const user = read().users.find((u) => u.id === membership.userId)!;
   const name = input.name.trim();
   if (!name) throw new Error("Enter a name");
@@ -63,30 +66,33 @@ export async function addRegistry(input: {
   if (!input.username.trim()) throw new Error("Enter a username");
   if (!input.password) throw new Error("Enter a password or access token");
 
-  const registry: Registry = {
-    id: newId("reg"),
-    teamId: membership.teamId,
-    name,
-    type: input.type,
-    registryUrl,
-    username: input.username.trim(),
-    passwordEnc: encryptSecret(input.password),
-    createdAt: nowIso(),
-  };
-  mutate((d) => {
-    d.registries ??= [];
-    d.registries.push(registry);
-  });
+  await getDb()
+    .insert(registriesTable)
+    .values({
+      id: newId("reg"),
+      teamId: membership.teamId,
+      name,
+      type: input.type,
+      registryUrl,
+      username: input.username.trim(),
+      passwordEnc: encryptSecret(input.password),
+      createdAt: nowIso(),
+    });
   recordActivity("member", `Added registry ${name}`, user.name, null, membership.teamId);
 }
 
 export async function deleteRegistry(id: string): Promise<void> {
   const { membership } = await requireCapability("manage_infra");
   const user = read().users.find((u) => u.id === membership.userId)!;
-  const r = registries().find((x) => x.id === id && x.teamId === membership.teamId);
+  const rows = await getDb()
+    .select({ name: registriesTable.name })
+    .from(registriesTable)
+    .where(and(eq(registriesTable.id, id), eq(registriesTable.teamId, membership.teamId)))
+    .limit(1);
+  const r = rows[0];
   if (!r) throw new Error("Registry not found");
-  mutate((d) => {
-    d.registries = (d.registries ?? []).filter((x) => x.id !== id);
-  });
+  await getDb()
+    .delete(registriesTable)
+    .where(and(eq(registriesTable.id, id), eq(registriesTable.teamId, membership.teamId)));
   recordActivity("member", `Removed registry ${r.name}`, user.name, null, membership.teamId);
 }

--- a/lib/data/tokens.test.ts
+++ b/lib/data/tokens.test.ts
@@ -1,0 +1,122 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { PGlite } from "@electric-sql/pglite";
+import { eq } from "drizzle-orm";
+
+import { makeTestDb, type TestDb } from "../db/test-harness";
+import { __setTestDb, __resetTestDb } from "../db/client";
+import { apiTokens } from "../db/schema/control-plane";
+import { runWithIdentity } from "../auth/request-context";
+import { seedIdentity, TEAM_A, TEAM_B, USER_1 } from "./leaf-test-helpers";
+import {
+  authenticateToken,
+  createToken,
+  listTokens,
+  revokeToken,
+} from "./tokens";
+
+/**
+ * Data-layer tests for the `api_tokens` leaf collection against pglite
+ * (relational-store PLAN Step 2). Drives the LIVE async functions (now backed by
+ * Drizzle) under a `runWithIdentity` principal, with identity seeded in the JSONB
+ * store and the FK roots seeded in pglite (see `leaf-test-helpers`).
+ */
+
+let db: TestDb;
+let pg: PGlite;
+
+before(async () => {
+  ({ db, pg } = await makeTestDb());
+  __setTestDb(db);
+});
+
+after(async () => {
+  __resetTestDb();
+  await pg.close();
+});
+
+beforeEach(async () => {
+  await pg.exec(`truncate table api_tokens, users, teams restart identity cascade;`);
+  await seedIdentity(db);
+});
+
+const asUser1 = <T>(fn: () => Promise<T>): Promise<T> =>
+  runWithIdentity({ userId: USER_1, teamId: TEAM_A }, fn);
+
+test("createToken returns the raw once and listTokens shows it (no secret)", async () => {
+  await asUser1(async () => {
+    const { raw, token } = await createToken("CI");
+    assert.ok(raw.startsWith("deplo_"), "raw token is a deplo_ token");
+    assert.equal(token.name, "CI");
+    assert.equal(token.lastUsedAt, null);
+
+    const list = await listTokens();
+    assert.equal(list.length, 1);
+    assert.equal(list[0]!.id, token.id);
+    assert.equal(list[0]!.prefix, raw.slice(0, 12));
+    // The DTO never carries the hash.
+    assert.equal("tokenHash" in list[0]!, false);
+  });
+
+  // The hash IS persisted (only the hash, never the raw).
+  const rows = await db.select().from(apiTokens);
+  assert.equal(rows.length, 1);
+  assert.notEqual(rows[0]!.tokenHash, "");
+});
+
+test("createToken rejects a blank name", async () => {
+  await asUser1(async () => {
+    await assert.rejects(() => createToken("   "), /Name is required/);
+  });
+});
+
+test("authenticateToken resolves a created token's principal and bumps lastUsedAt", async () => {
+  const raw = await asUser1(async () => (await createToken("CI")).raw);
+
+  const identity = await authenticateToken(raw);
+  assert.deepEqual(identity, { userId: USER_1, teamId: TEAM_A });
+
+  // lastUsedAt is stamped (fire-and-forget update); poll briefly since it's not awaited.
+  let stamped: string | null = null;
+  for (let i = 0; i < 50 && stamped === null; i++) {
+    const rows = await db.select().from(apiTokens).limit(1);
+    stamped = rows[0]!.lastUsedAt;
+    if (stamped === null) await new Promise((r) => setTimeout(r, 10));
+  }
+  assert.ok(stamped, "lastUsedAt was stamped after authentication");
+});
+
+test("authenticateToken returns null for an unknown or non-deplo token", async () => {
+  assert.equal(await authenticateToken("not-a-deplo-token"), null);
+  assert.equal(await authenticateToken("deplo_doesnotexist"), null);
+});
+
+test("revokeToken removes only the active team's matching token", async () => {
+  const id = await asUser1(async () => (await createToken("CI")).token.id);
+  await asUser1(async () => {
+    await revokeToken(id);
+    assert.equal((await listTokens()).length, 0);
+  });
+  assert.equal((await db.select().from(apiTokens).where(eq(apiTokens.id, id))).length, 0);
+});
+
+test("listTokens is scoped to the active team", async () => {
+  // Seed a second user/owner in team B and a token there; user_1 must not see it.
+  await pg.exec(`truncate table api_tokens, users, teams restart identity cascade;`);
+  await seedIdentity(db, {
+    users: [
+      { id: USER_1, teamId: TEAM_A, role: "owner" },
+      { id: "user_2", teamId: TEAM_B, role: "owner" },
+    ],
+  });
+
+  await runWithIdentity({ userId: "user_2", teamId: TEAM_B }, async () => {
+    await createToken("B-token");
+  });
+  await asUser1(async () => {
+    assert.equal((await listTokens()).length, 0, "user_1 sees no team-B tokens");
+    await createToken("A-token");
+    assert.equal((await listTokens()).length, 1);
+  });
+});

--- a/lib/data/tokens.ts
+++ b/lib/data/tokens.ts
@@ -1,10 +1,12 @@
 import "server-only";
 
-import { read, mutate } from "../store";
+import { and, desc, eq } from "drizzle-orm";
+
+import { getDb } from "../db/client";
+import { apiTokens } from "../db/schema/control-plane";
 import { newId, nowIso } from "../ids";
 import { requireActiveTeamId, requireCapability } from "../membership";
 import { sha256Hex, randomToken } from "../crypto";
-import type { ApiToken } from "../types";
 
 export interface ApiTokenDTO {
   id: string;
@@ -14,21 +16,22 @@ export interface ApiTokenDTO {
   createdAt: string;
 }
 
-function toDTO(t: ApiToken): ApiTokenDTO {
-  return {
-    id: t.id,
-    name: t.name,
-    prefix: t.prefix,
-    lastUsedAt: t.lastUsedAt,
-    createdAt: t.createdAt,
-  };
-}
+/** The non-secret projection — never selects `token_hash` (relational-store PLAN §1 "Secrets"). */
+const DTO_COLUMNS = {
+  id: apiTokens.id,
+  name: apiTokens.name,
+  prefix: apiTokens.prefix,
+  lastUsedAt: apiTokens.lastUsedAt,
+  createdAt: apiTokens.createdAt,
+} as const;
 
 export async function listTokens(): Promise<ApiTokenDTO[]> {
   const teamId = await requireActiveTeamId();
-  return read()
-    .apiTokens.filter((t) => t.teamId === teamId)
-    .map(toDTO);
+  return getDb()
+    .select(DTO_COLUMNS)
+    .from(apiTokens)
+    .where(eq(apiTokens.teamId, teamId))
+    .orderBy(desc(apiTokens.createdAt));
 }
 
 /** Returns the raw token ONCE; only the hash is persisted. */
@@ -36,19 +39,23 @@ export async function createToken(name: string): Promise<{ raw: string; token: A
   const { teamId, userId } = await requireCapability("manage_infra");
   if (!name.trim()) throw new Error("Name is required");
   const raw = `deplo_${randomToken(24)}`;
-  const t: ApiToken = {
+  const token: ApiTokenDTO = {
     id: newId("tok"),
-    teamId,
-    // The token acts as its creator for user-scoped fields on bearer requests.
-    userId,
     name: name.trim(),
-    tokenHash: sha256Hex(raw),
     prefix: raw.slice(0, 12),
     lastUsedAt: null,
     createdAt: nowIso(),
   };
-  mutate((d) => d.apiTokens.push(t));
-  return { raw, token: toDTO(t) };
+  await getDb()
+    .insert(apiTokens)
+    .values({
+      ...token,
+      teamId,
+      // The token acts as its creator for user-scoped fields on bearer requests.
+      userId,
+      tokenHash: sha256Hex(raw),
+    });
+  return { raw, token };
 }
 
 /**
@@ -56,28 +63,36 @@ export async function createToken(name: string): Promise<{ raw: string; token: A
  * does not match a live token. Bumps `lastUsedAt`. The GraphQL request context
  * uses this to authenticate external API clients. Never throws.
  */
-export function authenticateToken(
+export async function authenticateToken(
   raw: string,
-): { userId: string; teamId: string } | null {
+): Promise<{ userId: string; teamId: string } | null> {
   if (!raw.startsWith("deplo_")) return null;
   const hash = sha256Hex(raw);
-  const match = read().apiTokens.find((t) => t.tokenHash === hash);
+  const rows = await getDb()
+    .select({
+      id: apiTokens.id,
+      userId: apiTokens.userId,
+      teamId: apiTokens.teamId,
+    })
+    .from(apiTokens)
+    .where(eq(apiTokens.tokenHash, hash))
+    .limit(1);
+  const match = rows[0];
   if (!match) return null;
   // Fire-and-forget usage stamp; a failed write must not block the request.
-  try {
-    mutate((d) => {
-      const t = d.apiTokens.find((x) => x.id === match.id);
-      if (t) t.lastUsedAt = nowIso();
+  void getDb()
+    .update(apiTokens)
+    .set({ lastUsedAt: nowIso() })
+    .where(eq(apiTokens.id, match.id))
+    .catch(() => {
+      /* usage tracking is best-effort */
     });
-  } catch {
-    /* usage tracking is best-effort */
-  }
   return { userId: match.userId, teamId: match.teamId };
 }
 
 export async function revokeToken(id: string): Promise<void> {
   const teamId = (await requireCapability("manage_infra")).teamId;
-  mutate((d) => {
-    d.apiTokens = d.apiTokens.filter((x) => !(x.id === id && x.teamId === teamId));
-  });
+  await getDb()
+    .delete(apiTokens)
+    .where(and(eq(apiTokens.id, id), eq(apiTokens.teamId, teamId)));
 }

--- a/lib/db/backfill/cut-sets/leaf.ts
+++ b/lib/db/backfill/cut-sets/leaf.ts
@@ -1,11 +1,8 @@
 import { count, eq } from "drizzle-orm";
 
-import type {
-  DeploData,
-  NotificationEvent,
-  NotificationSettings,
-} from "../../../types";
+import type { DeploData, NotificationSettings } from "../../../types";
 import { defaultNotificationSettings } from "../../../types";
+import { settingsToRow } from "../../../data/notification-row";
 import { appSlug } from "../../../apps/runtime";
 import {
   apiTokens,
@@ -45,42 +42,10 @@ import { seedIdentityRoots } from "../roots";
  * resolution.
  */
 
-/* ------------------------------------------------------------------ */
-/* Notification settings: map row <-> flat columns                     */
-/* ------------------------------------------------------------------ */
-
-/**
- * One boolean column per {@link NotificationEvent}, declared `satisfies
- * Record<NotificationEvent, …>` so adding a new event to the union fails to
- * compile here until the backfill maps it — a settings event can't be silently
- * dropped (PLAN §7 "exhaustive … coverage").
- */
-const EVENT_COLUMN = {
-  deployment_failed: notificationSettings.deploymentFailed,
-  deployment_succeeded: notificationSettings.deploymentSucceeded,
-  server_offline: notificationSettings.serverOffline,
-  high_resource_usage: notificationSettings.highResourceUsage,
-  update_available: notificationSettings.updateAvailable,
-} satisfies Record<NotificationEvent, unknown>;
-
-/** Map a {@link NotificationSettings} object to its flat `notification_settings` row. */
-function notificationRow(teamId: string, s: NotificationSettings) {
-  return {
-    teamId,
-    pushEnabled: s.channels.push.enabled,
-    emailEnabled: s.channels.email.enabled,
-    emailAddress: s.channels.email.address,
-    discordEnabled: s.channels.discord.enabled,
-    discordWebhookUrl: s.channels.discord.webhookUrl,
-    webhookEnabled: s.channels.webhook.enabled,
-    webhookUrl: s.channels.webhook.url,
-    deploymentFailed: s.events.deployment_failed,
-    deploymentSucceeded: s.events.deployment_succeeded,
-    serverOffline: s.events.server_offline,
-    highResourceUsage: s.events.high_resource_usage,
-    updateAvailable: s.events.update_available,
-  };
-}
+// The flat-columns ↔ nested-object mapping (with its compile-time
+// exhaustiveness guard over every NotificationEvent) lives in
+// `lib/data/notification-row.ts` — the ONE shared mapping this cut-set's copy
+// and the live data layer both use, so the two can't drift (PLAN §2/§7).
 
 /* ------------------------------------------------------------------ */
 /* Copy                                                                */
@@ -141,7 +106,7 @@ async function copyLeaf(tx: BackfillTx, data: DeploData): Promise<void> {
   if (settingsEntries.length > 0) {
     await tx
       .insert(notificationSettings)
-      .values(settingsEntries.map(([teamId, s]) => notificationRow(teamId, s)));
+      .values(settingsEntries.map(([teamId, s]) => settingsToRow(teamId, s)));
   }
 
   await reconcileLeaf(tx, data);
@@ -240,16 +205,12 @@ export async function reconcileLeaf(
       .limit(1);
     const got = persisted[0];
     if (!got) fail(`notification_settings missing row for team ${teamId}`);
-    const want = notificationRow(teamId, raw as NotificationSettings);
+    const want = settingsToRow(teamId, raw as NotificationSettings);
     for (const key of Object.keys(want) as (keyof typeof want)[]) {
       if (got[key] !== want[key])
         fail(`notification_settings.${key} for ${teamId}: ${got[key]} != ${want[key]}`);
     }
   }
-
-  // Touch EVENT_COLUMN so the exhaustiveness guard is retained (it is the
-  // compile-time proof that every NotificationEvent maps to a column).
-  void EVENT_COLUMN;
 }
 
 /* ------------------------------------------------------------------ */

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -37,6 +37,35 @@ export type DrizzleClient = NodePgDatabase<typeof schema>;
 const CLIENT_KEY = Symbol.for("deplo.db.client.singleton");
 const g = globalThis as unknown as { [CLIENT_KEY]?: DrizzleClient };
 
+/**
+ * Test-only override (relational-store PLAN §8 "Engine parameterization", Step
+ * 2). The data layer calls `getDb()` with no `db` argument, so a `node --test`
+ * run needs a seam to point it at the pglite client `makeTestDb()` builds instead
+ * of the node-postgres pool (which would require a real Postgres). When set,
+ * `getDb()` returns it. Mirrors `lib/backups/lease.ts`'s `__resetLocalLeases()`
+ * test hook. Null in every real run, so production never pays for the branch
+ * beyond one comparison.
+ */
+let testOverride: DrizzleClient | null = null;
+
 export function getDb(): DrizzleClient {
+  if (testOverride) return testOverride;
   return (g[CLIENT_KEY] ??= drizzle(getPool(), { schema }));
+}
+
+/**
+ * Test-only: route every `getDb()` at the given client (a pglite
+ * `PgliteDatabase<typeof schema>` from `makeTestDb()`). The two Drizzle clients
+ * expose the same query surface (`select`/`insert`/`update`/`delete`/
+ * `transaction`) over the same `schema`; the structural mismatch is only in the
+ * driver HKT, so the harness passes it through this widening seam. Call in a
+ * test `before`; pair with {@link __resetTestDb} in `after`.
+ */
+export function __setTestDb(db: unknown): void {
+  testOverride = db as DrizzleClient;
+}
+
+/** Test-only: clear the {@link __setTestDb} override. */
+export function __resetTestDb(): void {
+  testOverride = null;
 }

--- a/lib/graphql/context.ts
+++ b/lib/graphql/context.ts
@@ -39,10 +39,10 @@ export interface GraphQLContext {
 export async function buildContext(
   request: Request,
 ): Promise<GraphQLContext> {
-  // In Postgres mode the in-memory store is hydrated lazily; `authenticateToken`
-  // reads it synchronously, so the cache must be ready before the first bearer
-  // request or the token lookup runs against an empty seed. (The cookie path
-  // already awaits this inside getCurrentUser.)
+  // Ensure the store/backfill gate has run before the first request: the cookie
+  // path awaits this inside getCurrentUser, but the bearer path below queries the
+  // relational `api_tokens` table (populated by the leaf backfill that
+  // ensureStoreReady gates), so it must be ready first.
   await ensureStoreReady();
 
   const auth = request.headers.get("authorization");
@@ -51,7 +51,7 @@ export async function buildContext(
     : null;
 
   if (bearer) {
-    const identity = authenticateToken(bearer);
+    const identity = await authenticateToken(bearer);
     if (!identity) {
       return {
         viewer: null,

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -81,6 +81,17 @@ type StoreState = {
    * we discard it in favour of the durable Postgres document.
    */
   dirty: boolean;
+  /**
+   * Single-flight for the relational-store cut-set backfills (relational-store
+   * PLAN §7, Step 2+). Separate from hydration: a migrated cut-set copies from
+   * the freshly-hydrated JSONB into its relational tables at most once per
+   * process, gated by the `store_migration` marker. `backfilled` flips true once
+   * every wired cut-set's gate has returned; `backfilling` is the in-flight run
+   * (re-armed to null on failure so the next ensureStoreReady retries — a backfill
+   * failure must NOT 500 the request path, PLAN §8).
+   */
+  backfilled: boolean;
+  backfilling: Promise<void> | null;
 };
 
 const STORE_KEY = Symbol.for("deplo.store.singleton");
@@ -92,6 +103,8 @@ const state: StoreState = (g[STORE_KEY] ??= {
   hydrating: null,
   writeChain: Promise.resolve(),
   dirty: false,
+  backfilled: false,
+  backfilling: null,
 });
 
 /* ------------------------------------------------------------------ */
@@ -113,17 +126,49 @@ function queuePostgresWrite(data: DeploData) {
 }
 
 /**
- * Hydrate the in-memory cache from Postgres. Idempotent and safe to call from
- * multiple concurrent requests — the work happens at most once. In the
- * test-only in-memory mode (no Postgres) this seeds the cache and returns
- * without touching any backend.
+ * Run every wired relational-store cut-set backfill once (relational-store PLAN
+ * §7, Step 2+). Each cut-set copies its collections from the freshly-hydrated
+ * JSONB (`state.cache`) into its relational tables, gated cross-process by the
+ * `store_migration` marker + scheduler-lease so it runs at most once even across
+ * a rolling-restart double-boot.
+ *
+ * It must NEVER throw out to the caller: `ensureStoreReady` is awaited on the
+ * request path (auth, webhooks, agent bootstrap) and a single-flight that caches
+ * a rejected promise would 500 the process for its whole life. A failure here is
+ * caught, logged, and the single-flight re-armed so the NEXT ensureStoreReady
+ * retries (the marker makes a successful re-run a no-op). Dynamically imported so
+ * the relational layer never loads on the test in-memory path (guarded by the
+ * USE_PG caller) and to avoid a static import cycle through `lib/store`.
+ */
+async function runCutSetBackfills(): Promise<void> {
+  const { getDb } = await import("./db/client");
+  const { awaitBackfill } = await import("./db/backfill/gate");
+  const { runBackfill } = await import("./db/backfill/engine");
+  const { leafCutSetCopy } = await import("./db/backfill/cut-sets/leaf");
+  const { CUT_SETS } = await import("./db/backfill/markers");
+  const db = getDb();
+  const owner = `pid-${process.pid}`;
+  const doc = state.cache!;
+
+  // Cut-set (a) — leaf collections (Step 2). Add later cut-sets here in order.
+  await awaitBackfill(db, CUT_SETS.leaf, owner, () =>
+    runBackfill(db, CUT_SETS.leaf, doc, leafCutSetCopy),
+  );
+}
+
+/**
+ * Hydrate the in-memory cache from Postgres AND run the relational-store cut-set
+ * backfills. Idempotent and safe to call from multiple concurrent requests — the
+ * work happens at most once. In the test-only in-memory mode (no Postgres) this
+ * seeds the cache and returns without touching any backend (no backfill).
  */
 export async function ensureStoreReady(): Promise<void> {
-  if (state.hydrated) return;
+  if (state.hydrated && state.backfilled) return;
   if (!USE_PG) {
-    // Test-only in-memory mode: seed once, never persist.
+    // Test-only in-memory mode: seed once, never persist, no relational backfill.
     if (!state.cache) state.cache = buildSeed();
     state.hydrated = true;
+    state.backfilled = true;
     return;
   }
   if (!state.hydrating) {
@@ -148,6 +193,29 @@ export async function ensureStoreReady(): Promise<void> {
     })();
   }
   await state.hydrating;
+
+  // Relational-store cut-set backfills run AFTER hydration (they copy from the
+  // freshly-hydrated, normalized JSONB). Gated by its own single-flight so it
+  // runs once even under concurrent callers, and re-armed on failure so a
+  // transient DB blip doesn't permanently cache a rejection.
+  if (!state.backfilled) {
+    if (!state.backfilling) {
+      state.backfilling = runCutSetBackfills().then(
+        () => {
+          state.backfilled = true;
+        },
+        (err) => {
+          console.error(
+            "[deplo] relational-store backfill failed; will retry on the next ensureStoreReady:",
+            err,
+          );
+          // Re-arm so the next call retries (the marker makes a good run a no-op).
+          state.backfilling = null;
+        },
+      );
+    }
+    await state.backfilling;
+  }
 }
 
 /* ------------------------------------------------------------------ */
@@ -193,6 +261,11 @@ export function mutate<T>(fn: (data: DeploData) => T): T {
 export function reseed(): DeploData {
   state.cache = buildSeed();
   state.hydrated = true;
+  // A reseed replaces the whole document; treat the relational backfill as
+  // settled too so the next ensureStoreReady doesn't re-run a copy over the
+  // fresh seed. (Used by tests in in-memory mode, where USE_PG is false and no
+  // relational backfill runs anyway.)
+  state.backfilled = true;
   state.dirty = true;
   if (USE_PG) queuePostgresWrite(state.cache);
   return state.cache;


### PR DESCRIPTION
Migrate the four leaf collections (apiTokens, notificationSettings, registries, installedApps) off the single-JSONB store onto their relational tables, atomically per PLAN cut-set (a) — the only zero-cost-revert set.

- Data layer (tokens/notifications/registries/apps) now queries Postgres via getDb() instead of sync read()/mutate(); authenticateToken is async (its one caller in graphql/context already awaited ensureStoreReady).
- getDb() gains a test-only override (__setTestDb/__resetTestDb) so the live data fns run against pglite under node --test.
- Leaf backfill runs inside ensureStoreReady() after hydrate, its own single-flight, catch+log+re-arm on failure — never throws (a cached rejection would 500 the request path for the life of the process).
- One shared notification_settings flat<->nested mapping (notification-row.ts, exhaustiveness-guarded) reused by the data layer and the leaf cut-set copy.

Identity/auth/membership and activities stay JSONB (cut-sets b/c, later steps); no module straddles the JSONB/relational boundary for any one collection.

Tests: per-collection pglite data-layer tests + an end-to-end backfill->async read fidelity test (shared leaf-test-helpers seeds identity in JSONB + FK roots in pglite, drives the live fns under runWithIdentity). Full suite 418 pass / 0 fail; tsc clean; db:generate reports no schema changes (zero DDL this step).