### PR TITLE
feat(store): Step 5 — cut-set (d) backups relational

### DIFF
--- a/docs/research/relational-store/PLAN.md
+++ b/docs/research/relational-store/PLAN.md
@@ -998,6 +998,89 @@ scheduler-test rewrite. *Test:* backup start/terminal atomicity, retention picks
 right object under a same-millisecond tie, reconcile-before-scheduler ordering, backfill
 fidelity.
 
+#### STEP 5 RESULT (2026-06-24) — DONE ✅
+
+Cut-set (d) shipped: `databases` + `s3_destination` + `backups` + `backup_runs` are
+all relational, migrated atomically with
+[lib/data/databases.ts](../../../lib/data/databases.ts),
+[lib/data/s3.ts](../../../lib/data/s3.ts),
+[lib/data/backups.ts](../../../lib/data/backups.ts),
+[lib/backups/scheduler.ts](../../../lib/backups/scheduler.ts), and the boot
+reconcile in [instrumentation.ts](../../../instrumentation.ts). **Full suite 480
+pass / 0 fail** (+27: backfill 5, databases 3, s3 4, backups 9, retention seq-tiebreak
++5, scheduler rewrite kept 6 — minus a couple folded), `tsc` clean (only the
+pre-existing `migrate.test.ts` cast), `eslint` clean (one pre-existing s3 `toDTO`
+warning), `db:generate` reports "no schema changes" (Step 1 emitted the tables).
+Highlights and decisions:
+
+- **One shared row-assembler is the anti-drift seam.**
+  [lib/data/backup-rows.ts](../../../lib/data/backup-rows.ts) is the ONE place
+  mapping the four collections' relational rows ↔ domain objects
+  (`assemble*` / `*ToRow`, each `*ToRow` exhaustive via `satisfies Record<keyof …>`);
+  the live data layer (read), the scheduler, and the backfill (write + reconcile)
+  all go through it (the same rationale as `project-graph-rows.ts` for cut-set (c)
+  and `notification-row.ts` for the leaf). The load-bearing asymmetry it isolates:
+  `BackupRun` (domain) has no `seq`, but `backup_runs` carries a DB-generated
+  `bigint identity seq` — `backupRunToRow` never writes it, `assembleBackupRun`
+  drops it, and retention reads it via a dedicated `RunForRetention` projection.
+- **`seq` tiebreak closes the same-millisecond retention hazard (PLAN §5).**
+  `selectDoomedRuns` ([backup-objectkey.ts](../../../lib/data/backup-objectkey.ts))
+  now ranks newest-first by `(startedAt, seq)` DESC, not `startedAt` alone — a
+  same-ms tie ordered by timestamp could keep/`S3Delete` the WRONG object. The
+  retention candidate query selects `seq`; `listBackupRuns` pushes
+  `ORDER BY started_at DESC, seq DESC` into SQL (matches `backup_runs_team_started_idx`).
+  A unit test drives three same-instant runs and asserts the highest-`seq` success
+  is kept regardless of input order.
+- **The two-tx `executeBackup` is preserved exactly (PLAN §1 rule (a)).** The START
+  write (insert `running` run + stamp the schedule) and the TERMINAL write (flip the
+  run + settle the schedule) are each a short `db.transaction`; the gRPC
+  `conn.backup()` dump + the retention `s3Delete` loop run BETWEEN them, never inside
+  a tx. The mid-flight objectKey record is a single UPDATE. A data-layer test drives
+  the full path with an unreachable agent and asserts both transactions ran (the run
+  is recorded `running` then flipped `failed`, the schedule's `lastRunAt`/`lastStatus`
+  stamped). Same shape preserved for `deleteDatabase`/`testS3`/`deleteBackupArtifacts`
+  (agent RPC outside the row write).
+- **The FK cascades replace the hand-maintained orphan filters.** `deleteDatabase`
+  is now one `DELETE` (agent teardown OUTSIDE it); the `backups.database_id` CASCADE
+  removes dependent schedules and `backup_runs.database_id` SET NULL keeps run
+  history (was a manual `d.backups` filter that orphaned runs). `deleteS3` is one
+  transaction deleting dependent schedules AND runs explicitly — `destination_id` is
+  RESTRICT (a destination must never be silently cascade-removed from under live
+  schedules/restore points), and the JSONB version orphaned run history with a
+  dangling `destinationId`, which the RESTRICT FK now forbids. Data-layer tests
+  assert no orphans on either path.
+- **Backfill (cut-set d) runs LAST + prunes the legacy orphans.**
+  [lib/db/backfill/cut-sets/backups.ts](../../../lib/db/backfill/cut-sets/backups.ts)
+  copies FK-ordered (`s3_destination` → `databases` → `backups` → `backup_runs`),
+  seeding identity + `servers` roots idempotently (`seedServers` extracted to
+  [roots.ts](../../../lib/db/backfill/roots.ts), shared with cut-set (c)). It PRUNES
+  a schedule whose target (database/project) or destination is dead (the
+  `deleteDatabase`/`deleteProject` orphan leaks the RESTRICT FK + `target_kind` XOR
+  forbid), and for a run (history outlives its target via SET-NULL FKs) NULLs a dead
+  `databaseId`/`projectId`/`backupId` while pruning a run whose RESTRICT
+  `destinationId` is gone. Runs insert in source-array order so `seq` reproduces
+  insertion order. The element-granular reconcile asserts post-prune counts, the
+  schedule XOR, and every FK resolves. Tests cover fidelity, the prune cases, the
+  run-FK NULLing, idempotent re-run, fresh-install-zero, and rollback-on-mismatch.
+- **Boot ordering: backup reconcile AWAITED before the scheduler.**
+  `reconcileInFlightBackupRuns` went sync→async (one tx: flip stale `running` runs
+  `failed` RETURNING their schedule ids, then settle those stuck schedules);
+  `instrumentation.ts` now `await`s it before `startBackupScheduler()` so the first
+  tick never reads an un-reconciled `running` run. The scheduler reads enabled
+  schedules via a relational `enabled` query (cron match + per-minute dedup stay in
+  memory).
+- **Test backend:** `backup-test-helpers.ts` seeds databases/s3/schedules/runs
+  relationally; `scheduler.test.ts` was rewritten off the deleted `store.read/mutate`
+  onto the pglite harness (PLAN §8 "rewrite store-coupled tests in the cut-set"),
+  resetting the `globalThis` scheduler singleton between cases.
+- **Cut-set CLOSURE was clean.** An adversarial scan for stale JSONB reads of these
+  four collections outside the migrated modules found NONE — every reader/writer was
+  already one of `databases.ts`/`s3.ts`/`backups.ts`/`scheduler.ts`/`instrumentation.ts`;
+  the GraphQL resolvers + pages call only the (unchanged-signature) public data-layer
+  functions, and `project-backup-descriptor.ts` already reads relational project-graph
+  data. The only signature changes (`getS3WithSecretsForTeam` sync→async,
+  `reconcileInFlightBackupRuns` sync→async) have no callers outside the cut-set.
+
 **Step 6 — Cutover: delete the cache and JSONB write path.** Remove the `globalThis`
 `StoreState` cache, `queuePostgresWrite`, `writeChain`, `state.dirty`, the `load()`
 seed-then-adopt crutch, and `read`/`mutate`. `ensureStoreReady()` keeps only the

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -34,7 +34,9 @@ export async function register(): Promise<void> {
       console.error("[deplo] deployment reconcile failed:", e),
     );
     const { reconcileInFlightBackupRuns } = await import("./lib/data/backups");
-    reconcileInFlightBackupRuns();
+    // AWAITED (now relational/async): the backup reconcile MUST complete before
+    // the scheduler's first tick reads a `running` run it never settled.
+    await reconcileInFlightBackupRuns();
     // Start the backup scheduler after the reconcile so a boot tick never trips
     // over an orphaned `running` run. Idempotent + lease-guarded internally.
     const { startBackupScheduler } = await import("./lib/backups/scheduler");

--- a/lib/backups/scheduler.test.ts
+++ b/lib/backups/scheduler.test.ts
@@ -1,145 +1,146 @@
 import { test, before, beforeEach, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+
+import type { PGlite } from "@electric-sql/pglite";
+import { eq } from "drizzle-orm";
+
+import { makeTestDb, type TestDb } from "../db/test-harness";
+import { __setTestDb, __resetTestDb } from "../db/client";
+import { backupRuns as backupRunsTable } from "../db/schema/control-plane";
+import { seedIdentity, TEAM_A, USER_1 } from "../data/identity-test-helpers";
+import { seedServer } from "../data/project-graph-test-helpers";
+import {
+  seedBackup,
+  seedDatabase,
+  seedS3,
+  TRUNCATE_BACKUPS,
+} from "../data/backup-test-helpers";
+import { runWithIdentity } from "../auth/request-context";
 
 /**
- * Scheduler-tick tests (Step 6). These exercise the ORCHESTRATION — due
- * selection, the per-minute dedup guard, and the cross-process lease — not a real
- * dump. The schedules here point at a destination that doesn't exist, so
- * `executeBackup` fails fast at the (session-free) creds lookup and records a
- * `failed` BackupRun WITHOUT any network: the run record is our proof the tick
- * fired that schedule. The cron matcher + lease CAS have their own focused tests.
+ * Scheduler-tick tests (PLAN Step 5 cut-set (d) — the scheduler-test rewrite off
+ * the deleted `store.read/mutate` onto the Drizzle test harness). These exercise
+ * the ORCHESTRATION — due selection (now a relational `enabled` query + the
+ * in-memory cron match), the per-minute dedup guard, and the cross-process lease —
+ * NOT a real dump. The schedules point at a real destination + database, so
+ * `executeBackup` runs end to end with NO request context until the owning agent
+ * dial fails (the seeded server has no live agent), recording a `failed`
+ * `BackupRun`: that run record is our proof the tick fired the schedule.
  *
- * With no DEPLO_DATABASE_URL the store runs in its test-only in-memory mode and
- * the lease takes its in-process path — exactly the single-process `next start`
- * shape Step 6 targets.
+ * With no DEPLO_DATABASE_URL the lease takes its in-process path — exactly the
+ * single-process `next start` shape the scheduler targets — while the data layer
+ * reads the injected pglite client (`__setTestDb`).
  */
 
-// No DEPLO_DATABASE_URL → in-memory store (test-only). DEPLO_DATA_DIR points
-// build/upload staging at a throwaway dir; set BEFORE the modules load.
-const dataDir = mkdtempSync(join(tmpdir(), "deplo-sched-"));
-process.env.DEPLO_DATA_DIR = dataDir;
-delete process.env.DEPLO_DATABASE_URL;
-delete process.env.DATABASE_URL;
-
-let store: typeof import("../store");
+let db: TestDb;
+let pg: PGlite;
 let scheduler: typeof import("./scheduler");
 let lease: typeof import("./lease");
-import type { Backup } from "../types";
 
 before(async () => {
-  store = await import("../store");
+  ({ db, pg } = await makeTestDb());
+  __setTestDb(db);
   scheduler = await import("./scheduler");
   lease = await import("./lease");
 });
 
-after(() => {
-  rmSync(dataDir, { recursive: true, force: true });
+after(async () => {
+  __resetTestDb();
+  await pg.close();
 });
 
-const TEAM = "team_sched";
-
-/** A backup schedule targeting a database, pointed at a missing destination. */
-function makeBackup(over: Partial<Backup> = {}): Backup {
-  return {
-    id: `bkp_${Math.random().toString(16).slice(2)}`,
-    teamId: TEAM,
-    name: "nightly",
-    targetKind: "database",
-    databaseId: "db_x",
-    projectId: null,
-    destinationId: "s3_missing", // does not exist → executeBackup fails fast
-    schedule: "* * * * *", // due every minute
-    retentionDays: 7,
-    lastRunAt: null,
-    lastStatus: "never",
-    enabled: true,
-    createdAt: new Date("2026-01-01T00:00:00Z").toISOString(),
-    ...over,
-  };
-}
-
-beforeEach(() => {
-  // Fresh store + a clean in-process lease before each case.
-  store.reseed();
+beforeEach(async () => {
+  // Reset the globalThis scheduler singleton (its per-minute `lastFired` dedup map
+  // + held lease) so a previous case's fired schedule can't bleed across tests.
+  await scheduler.__stopBackupScheduler();
+  await pg.exec(`${TRUNCATE_BACKUPS}
+    truncate table project_build_method_settings, project_build, projects, servers,
+      users, teams restart identity cascade;`);
+  await seedIdentity(db, { users: [{ id: USER_1, teamId: TEAM_A, role: "owner" }] });
+  await seedServer(db);
+  await seedDatabase(db, { id: "db_x", name: "x" });
+  await seedS3(db, { id: "s3_1" });
   lease.__resetLocalLeases();
 });
 
-const runsFor = (id: string) =>
-  store.read().backupRuns.filter((r) => r.backupId === id);
+/** Seed a due-every-minute schedule (overridable). Returns its id. */
+async function seedDue(id: string, over: Parameters<typeof seedBackup>[1] | object = {}) {
+  return seedBackup(db, {
+    id,
+    destinationId: "s3_1",
+    databaseId: "db_x",
+    schedule: "* * * * *",
+    ...(over as object),
+  });
+}
+
+const runsFor = (backupId: string) =>
+  db.select().from(backupRunsTable).where(eq(backupRunsTable.backupId, backupId));
 
 const NOW = new Date("2026-06-23T12:00:00Z");
 
+// The scheduler runs session-free; give the data layer a principal anyway so any
+// incidental cookie-free read has a team (the executor uses the schedule's teamId).
+const tick = (now: Date) =>
+  runWithIdentity({ userId: USER_1, teamId: TEAM_A }, () => scheduler.runSchedulerTick(now));
+
 test("a due, enabled schedule fires exactly once per tick", async () => {
-  const b = makeBackup();
-  store.mutate((d) => d.backups.push(b));
+  await seedDue("bkp_1");
 
-  await scheduler.runSchedulerTick(NOW);
+  await tick(NOW);
 
-  const runs = runsFor(b.id);
+  const runs = await runsFor("bkp_1");
   assert.equal(runs.length, 1, "one BackupRun recorded for the due schedule");
-  // It failed (missing destination) but the schedule's lastStatus reflects it —
-  // proof the unattended executor ran end to end without a session.
-  assert.equal(runs[0].status, "failed");
-  assert.equal(runs[0].teamId, TEAM);
+  // It failed (unreachable agent) but the run record proves the unattended
+  // executor ran end to end without a session.
+  assert.equal(runs[0]!.status, "failed");
+  assert.equal(runs[0]!.teamId, TEAM_A);
 });
 
 test("a disabled schedule and a non-due schedule do not fire", async () => {
-  const disabled = makeBackup({ enabled: false });
-  // Due only at 03:00; NOW is 12:00.
-  const notDue = makeBackup({ schedule: "0 3 * * *" });
-  store.mutate((d) => d.backups.push(disabled, notDue));
+  await seedDue("disabled", { enabled: false });
+  await seedDue("notDue", { schedule: "0 3 * * *" }); // due at 03:00; NOW is 12:00
 
-  await scheduler.runSchedulerTick(NOW);
+  await tick(NOW);
 
-  assert.equal(runsFor(disabled.id).length, 0);
-  assert.equal(runsFor(notDue.id).length, 0);
+  assert.equal((await runsFor("disabled")).length, 0);
+  assert.equal((await runsFor("notDue")).length, 0);
 });
 
 test("dedup: two ticks in the same minute fire a schedule only once", async () => {
-  const b = makeBackup();
-  store.mutate((d) => d.backups.push(b));
+  await seedDue("bkp_1");
 
-  await scheduler.runSchedulerTick(NOW);
-  await scheduler.runSchedulerTick(new Date(NOW.getTime() + 5_000)); // same minute
+  await tick(NOW);
+  await tick(new Date(NOW.getTime() + 5_000)); // same minute
 
-  assert.equal(runsFor(b.id).length, 1, "second same-minute tick is deduped");
+  assert.equal((await runsFor("bkp_1")).length, 1, "second same-minute tick is deduped");
 });
 
 test("a new minute fires the schedule again", async () => {
-  const b = makeBackup();
-  store.mutate((d) => d.backups.push(b));
+  await seedDue("bkp_1");
 
-  await scheduler.runSchedulerTick(NOW);
-  await scheduler.runSchedulerTick(new Date(NOW.getTime() + 60_000)); // next minute
+  await tick(NOW);
+  await tick(new Date(NOW.getTime() + 60_000)); // next minute
 
-  assert.equal(runsFor(b.id).length, 2, "a distinct minute re-fires");
+  assert.equal((await runsFor("bkp_1")).length, 2, "a distinct minute re-fires");
 });
 
 test("the lease prevents a double-run: a tick that can't claim it does nothing", async () => {
-  const b = makeBackup();
-  store.mutate((d) => d.backups.push(b));
+  await seedDue("bkp_1");
 
   // Simulate another live instance already holding the scheduler lease.
-  const held = await lease.acquireLease(
-    lease.BACKUP_SCHEDULER_LEASE,
-    "another-instance",
-    NOW,
-  );
+  const held = await lease.acquireLease(lease.BACKUP_SCHEDULER_LEASE, "another-instance", NOW);
   assert.equal(held, true);
 
-  await scheduler.runSchedulerTick(NOW);
+  await tick(NOW);
 
-  assert.equal(runsFor(b.id).length, 0, "no run fired while the lease is held elsewhere");
+  assert.equal((await runsFor("bkp_1")).length, 0, "no run fired while the lease is held elsewhere");
 });
 
 test("a malformed cron in a schedule never fires and never throws", async () => {
-  const b = makeBackup({ schedule: "not a cron" });
-  store.mutate((d) => d.backups.push(b));
+  await seedDue("bkp_1", { schedule: "not a cron" });
 
-  await scheduler.runSchedulerTick(NOW); // must not throw
+  await tick(NOW); // must not throw
 
-  assert.equal(runsFor(b.id).length, 0);
+  assert.equal((await runsFor("bkp_1")).length, 0);
 });

--- a/lib/backups/scheduler.ts
+++ b/lib/backups/scheduler.ts
@@ -3,7 +3,11 @@ import "server-only";
 import { hostname } from "node:os";
 import { randomBytes } from "node:crypto";
 
-import { read } from "../store";
+import { eq } from "drizzle-orm";
+
+import { getDb } from "../db/client";
+import { backups as backupsTable } from "../db/schema/control-plane";
+import { assembleBackup } from "../data/backup-rows";
 import { runScheduledBackup } from "../data/backups";
 import { cronMatches } from "./cron";
 import {
@@ -85,15 +89,21 @@ export async function runSchedulerTick(now: Date = new Date()): Promise<void> {
     if (!held) return;
 
     const key = minuteKey(now);
-    // Snapshot the enabled, well-formed schedules due this minute. Reading is
-    // synchronous; the run itself awaits, so capture the list up front.
-    const due = read().backups.filter(
-      (b) =>
-        b.enabled &&
-        b.schedule &&
-        cronMatches(b.schedule, now) &&
-        state.lastFired.get(b.id) !== key,
-    );
+    // Snapshot the enabled, well-formed schedules due this minute. The enabled
+    // filter is pushed into SQL; `cronMatches` (and the per-minute dedup) stay in
+    // memory. Capture the list up front, then await each run.
+    const enabledRows = await getDb()
+      .select()
+      .from(backupsTable)
+      .where(eq(backupsTable.enabled, true));
+    const due = enabledRows
+      .map(assembleBackup)
+      .filter(
+        (b) =>
+          b.schedule &&
+          cronMatches(b.schedule, now) &&
+          state.lastFired.get(b.id) !== key,
+      );
 
     for (const b of due) {
       // Stamp BEFORE awaiting so a re-entrant/overlapping tick in the same minute

--- a/lib/data/backup-objectkey.test.ts
+++ b/lib/data/backup-objectkey.test.ts
@@ -7,6 +7,7 @@ import {
   targetPrefix,
   buildObjectKey,
   selectDoomedRuns,
+  type RunForRetention,
 } from "./backup-objectkey";
 import type { BackupRun } from "../types";
 
@@ -145,4 +146,44 @@ test("retention: nothing to prune within window and under cap", () => {
   const runs = [run("a", 0), run("b", 1), run("c", 2)];
   const doomed = selectDoomedRuns(runs, { retentionDays: 7, maxPerTarget: 50, now: NOW });
   assert.deepEqual(doomed, []);
+});
+
+/* ------------------------------------------------------------------ */
+/* Retention seq tiebreak (PLAN §5) — same-millisecond runs               */
+/* ------------------------------------------------------------------ */
+
+/** Two runs at the SAME instant, ordered only by their DB `seq`. */
+const sameMsRun = (
+  id: string,
+  seq: number,
+  over: Partial<BackupRun> = {},
+): RunForRetention => ({ ...run(id, 30), seq, ...over });
+
+test("retention: a same-ms tie keeps the higher-seq success (newest), prunes the rest", () => {
+  // Three successes ALL at the same (old) instant: timestamp alone can't order
+  // them, so without seq the "newest success to keep" is non-deterministic and
+  // could delete the live object. With seq, the highest-seq run is newest.
+  const runs = [sameMsRun("low", 1), sameMsRun("mid", 2), sameMsRun("high", 3)];
+  const doomed = selectDoomedRuns(runs, { retentionDays: 7, maxPerTarget: 50, now: NOW });
+  // "high" (seq 3) is the kept newest success; the two older same-ms runs are doomed.
+  assert.deepEqual(doomed.map((r) => r.id).sort(), ["low", "mid"]);
+});
+
+test("retention: same-ms tiebreak is independent of input array order", () => {
+  // Same three runs, shuffled — seq, not array position, decides "newest".
+  const runs = [sameMsRun("mid", 2), sameMsRun("high", 3), sameMsRun("low", 1)];
+  const doomed = selectDoomedRuns(runs, { retentionDays: 7, maxPerTarget: 50, now: NOW });
+  assert.deepEqual(doomed.map((r) => r.id).sort(), ["low", "mid"]);
+});
+
+test("retention: the cap counts newest-first by (startedAt, seq) under a tie", () => {
+  // Five same-instant runs, cap 2 → the 2 newest (highest seq) survive the cap,
+  // plus the kept-newest rule overlaps with the highest. Deterministic via seq.
+  const runs = [
+    sameMsRun("s1", 1), sameMsRun("s2", 2), sameMsRun("s3", 3),
+    sameMsRun("s4", 4), sameMsRun("s5", 5),
+  ];
+  const doomed = selectDoomedRuns(runs, { retentionDays: 365, maxPerTarget: 2, now: NOW });
+  // newest-first = s5,s4,s3,s2,s1; idx>=2 (s3,s2,s1) are over the cap.
+  assert.deepEqual(doomed.map((r) => r.id).sort(), ["s1", "s2", "s3"]);
 });

--- a/lib/data/backup-objectkey.ts
+++ b/lib/data/backup-objectkey.ts
@@ -1,6 +1,17 @@
 import type { BackupRun, BackupTargetKind, DatabaseType } from "../types";
 
 /**
+ * A {@link BackupRun} plus its DB-generated `seq` (the `bigint identity` on
+ * `backup_runs`, PLAN §5) — the shape retention ranks. `seq` totally orders runs
+ * written in the same millisecond (a lexicographic `startedAt` sort ties them and
+ * could `S3Delete` the WRONG object on a same-ms tie), so it is the tiebreaker
+ * after `startedAt`. The relational `pruneRetention` query selects `seq`; a unit
+ * test may omit it (the comparator falls back to insertion order for a missing
+ * `seq`, preserving the legacy behaviour it asserts).
+ */
+export type RunForRetention = BackupRun & { seq?: number };
+
+/**
  * Object-key + artifact-extension helpers for backups. Pure (no store, no
  * `server-only`) so they unit-test in isolation and can be shared by the
  * executor, the retention pruner, and any future lister.
@@ -91,15 +102,27 @@ export function buildObjectKey(input: {
  *
  * Failed runs own no S3 object, so the caller only issues `S3Delete` for the
  * doomed runs that succeeded — but it still drops the failed run records here, so
- * a long tail of failures can't grow the JSONB array unbounded.
+ * a long tail of failures can't grow the table unbounded.
+ *
+ * "Newest first" is `(startedAt, seq)` DESC, NOT `startedAt` alone (PLAN §5): two
+ * runs written in the same millisecond tie on the timestamp, and ordering them by
+ * timestamp alone is non-deterministic — it could pick the wrong "newest
+ * successful run to keep" and then `S3Delete` the live object. The DB-generated
+ * `seq` (`bigint identity`) breaks that tie by insertion order. The relational
+ * `pruneRetention` selects `seq`; if a caller omits it (a unit test asserting the
+ * legacy timestamp-only behaviour), the tie falls back to the input order.
  */
 export function selectDoomedRuns(
-  runs: BackupRun[],
+  runs: RunForRetention[],
   opts: { retentionDays: number; maxPerTarget: number; now: Date },
-): BackupRun[] {
-  const ordered = [...runs].sort((a, b) =>
-    a.startedAt < b.startedAt ? 1 : a.startedAt > b.startedAt ? -1 : 0,
-  ); // newest first
+): RunForRetention[] {
+  const ordered = [...runs].sort((a, b) => {
+    if (a.startedAt !== b.startedAt) return a.startedAt < b.startedAt ? 1 : -1;
+    // Same-millisecond tie: `seq` DESC (newer insertion first). Absent seq keeps
+    // the input order (stable for the legacy unit test).
+    if (a.seq !== undefined && b.seq !== undefined) return b.seq - a.seq;
+    return 0;
+  }); // newest first
   const cutoff = opts.now.getTime() - opts.retentionDays * 24 * 60 * 60 * 1000;
   const newestSuccessId = ordered.find((r) => r.status === "success")?.id ?? null;
   return ordered.filter((r, idx) => {

--- a/lib/data/backup-rows.ts
+++ b/lib/data/backup-rows.ts
@@ -1,0 +1,222 @@
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+
+import {
+  backups,
+  backupRuns,
+  databases,
+  s3Destination,
+} from "../db/schema/control-plane";
+import type {
+  Backup,
+  BackupRun,
+  BackupRunStatus,
+  BackupTargetKind,
+  Database,
+  DatabaseStatus,
+  DatabaseType,
+  S3Destination,
+  S3Provider,
+  S3Status,
+} from "../types";
+
+/**
+ * The ONE relational-rows ↔ domain-objects mapping for the backups cut-set (d)
+ * (relational-store PLAN §3 cut-set (d) / §2 the data aggregate): `databases`,
+ * `s3_destination`, `backups`, `backup_runs`. Both the live data layer (reads,
+ * `lib/data/{databases,s3,backups}.ts`) and the backfill
+ * (`lib/db/backfill/cut-sets/backups.ts`, write + reconcile) go through here, so
+ * the two can't drift on how a row folds into a domain object — the same
+ * anti-drift seam `project-graph-rows.ts` is for cut-set (c) and
+ * `notification-row.ts` is for the leaf cut-set.
+ *
+ * Pure — no `server-only`, no store, no db handle — so a `server-only` module and
+ * a backfill helper can both import it. These four collections are FLAT (no nested
+ * objects, lists, or junctions), so each mapping is a column↔field rename; the
+ * load-bearing detail is the `seq` asymmetry: `BackupRun` (the domain type) has no
+ * `seq`, but `backup_runs` carries a DB-generated `bigint identity seq` (PLAN §5).
+ * {@link backupRunToRow} therefore NEVER writes `seq` (the DB assigns it in
+ * insertion order); {@link assembleBackupRun} drops it (the domain object never
+ * carries it — retention reads it via a dedicated projection, not the DTO).
+ */
+
+export type DatabaseRow = InferSelectModel<typeof databases>;
+export type DatabaseInsert = InferInsertModel<typeof databases>;
+export type S3DestinationRow = InferSelectModel<typeof s3Destination>;
+export type S3DestinationInsert = InferInsertModel<typeof s3Destination>;
+export type BackupRow = InferSelectModel<typeof backups>;
+export type BackupInsert = InferInsertModel<typeof backups>;
+export type BackupRunRow = InferSelectModel<typeof backupRuns>;
+export type BackupRunInsert = InferInsertModel<typeof backupRuns>;
+
+/* ------------------------------------------------------------------ */
+/* databases                                                           */
+/* ------------------------------------------------------------------ */
+
+/** Explode a {@link Database} into its `databases` row (exhaustive via satisfies). */
+export function databaseToRow(d: Database): DatabaseInsert {
+  return {
+    id: d.id,
+    teamId: d.teamId,
+    name: d.name,
+    type: d.type,
+    version: d.version,
+    status: d.status,
+    serverId: d.serverId,
+    host: d.host,
+    port: d.port,
+    connectionStringEnc: d.connectionStringEnc,
+    exposedPublicly: d.exposedPublicly,
+    sizeMb: d.sizeMb,
+    createdAt: d.createdAt,
+  } satisfies Record<keyof Database, unknown> as DatabaseInsert;
+}
+
+/** Reassemble a `databases` row into a {@link Database}. */
+export function assembleDatabase(row: DatabaseRow): Database {
+  return {
+    id: row.id,
+    teamId: row.teamId,
+    name: row.name,
+    type: row.type as DatabaseType,
+    version: row.version,
+    status: row.status as DatabaseStatus,
+    serverId: row.serverId,
+    host: row.host,
+    port: row.port,
+    connectionStringEnc: row.connectionStringEnc,
+    exposedPublicly: row.exposedPublicly,
+    sizeMb: row.sizeMb,
+    createdAt: row.createdAt,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* s3_destination                                                      */
+/* ------------------------------------------------------------------ */
+
+/** Explode an {@link S3Destination} into its `s3_destination` row. */
+export function s3ToRow(s: S3Destination): S3DestinationInsert {
+  return {
+    id: s.id,
+    teamId: s.teamId,
+    name: s.name,
+    provider: s.provider,
+    endpoint: s.endpoint,
+    region: s.region,
+    bucket: s.bucket,
+    accessKeyEnc: s.accessKeyEnc,
+    secretKeyEnc: s.secretKeyEnc,
+    status: s.status,
+    createdAt: s.createdAt,
+  } satisfies Record<keyof S3Destination, unknown> as S3DestinationInsert;
+}
+
+/** Reassemble an `s3_destination` row into an {@link S3Destination}. */
+export function assembleS3(row: S3DestinationRow): S3Destination {
+  return {
+    id: row.id,
+    teamId: row.teamId,
+    name: row.name,
+    provider: row.provider as S3Provider,
+    endpoint: row.endpoint,
+    region: row.region,
+    bucket: row.bucket,
+    accessKeyEnc: row.accessKeyEnc,
+    secretKeyEnc: row.secretKeyEnc,
+    status: row.status as S3Status,
+    createdAt: row.createdAt,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* backups (schedule)                                                  */
+/* ------------------------------------------------------------------ */
+
+/** Explode a {@link Backup} schedule into its `backups` row. */
+export function backupToRow(b: Backup): BackupInsert {
+  return {
+    id: b.id,
+    teamId: b.teamId,
+    name: b.name,
+    targetKind: b.targetKind,
+    databaseId: b.databaseId,
+    projectId: b.projectId,
+    destinationId: b.destinationId,
+    schedule: b.schedule,
+    retentionDays: b.retentionDays,
+    lastRunAt: b.lastRunAt,
+    lastStatus: b.lastStatus,
+    enabled: b.enabled,
+    createdAt: b.createdAt,
+  } satisfies Record<keyof Backup, unknown> as BackupInsert;
+}
+
+/** Reassemble a `backups` row into a {@link Backup} schedule. */
+export function assembleBackup(row: BackupRow): Backup {
+  return {
+    id: row.id,
+    teamId: row.teamId,
+    name: row.name,
+    targetKind: row.targetKind as BackupTargetKind,
+    databaseId: row.databaseId,
+    projectId: row.projectId,
+    destinationId: row.destinationId,
+    schedule: row.schedule,
+    retentionDays: row.retentionDays,
+    lastRunAt: row.lastRunAt,
+    lastStatus: row.lastStatus as Backup["lastStatus"],
+    enabled: row.enabled,
+    createdAt: row.createdAt,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* backup_runs (history)                                               */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Explode a {@link BackupRun} into its `backup_runs` row. NEVER writes `seq` — it
+ * is a `bigint identity` the DB assigns in insertion order (PLAN §5), so a copy /
+ * insert in source-array order reproduces the run history's order. (`seq` is
+ * `generatedAlwaysAsIdentity`, so even passing it would be rejected.)
+ */
+export function backupRunToRow(r: BackupRun): BackupRunInsert {
+  return {
+    id: r.id,
+    teamId: r.teamId,
+    backupId: r.backupId,
+    targetKind: r.targetKind,
+    databaseId: r.databaseId,
+    projectId: r.projectId,
+    destinationId: r.destinationId,
+    objectKey: r.objectKey,
+    sizeBytes: r.sizeBytes,
+    status: r.status,
+    error: r.error,
+    startedAt: r.startedAt,
+    finishedAt: r.finishedAt,
+  } satisfies Record<keyof BackupRun, unknown> as BackupRunInsert;
+}
+
+/**
+ * Reassemble a `backup_runs` row into a {@link BackupRun}. Drops `seq` (the domain
+ * object never carries it — retention reads it via a dedicated `seq`-bearing
+ * projection, {@link import("./backup-objectkey").RunForRetention}).
+ */
+export function assembleBackupRun(row: BackupRunRow): BackupRun {
+  return {
+    id: row.id,
+    teamId: row.teamId,
+    backupId: row.backupId,
+    targetKind: row.targetKind as BackupTargetKind,
+    databaseId: row.databaseId,
+    projectId: row.projectId,
+    destinationId: row.destinationId,
+    objectKey: row.objectKey,
+    sizeBytes: row.sizeBytes,
+    status: row.status as BackupRunStatus,
+    error: row.error,
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt,
+  };
+}

--- a/lib/data/backup-test-helpers.ts
+++ b/lib/data/backup-test-helpers.ts
@@ -1,0 +1,179 @@
+import {
+  backups as backupsTable,
+  backupRuns as backupRunsTable,
+  databases as databasesTable,
+  s3Destination as s3Table,
+} from "../db/schema/control-plane";
+import {
+  backupToRow,
+  backupRunToRow,
+  databaseToRow,
+  s3ToRow,
+} from "./backup-rows";
+import { encryptSecret } from "../crypto";
+import type { TestDb } from "../db/test-harness";
+import type {
+  Backup,
+  BackupRun,
+  Database,
+  S3Destination,
+} from "../types";
+import { TEAM_A } from "./identity-test-helpers";
+import { SERVER_1 } from "./project-graph-test-helpers";
+
+/**
+ * Shared seeding for the backups cut-set (d) data-layer + scheduler tests
+ * (relational-store PLAN Step 5). The four collections are RELATIONAL: the data
+ * layer + the scheduler read pglite. So this seeds `databases` / `s3_destination`
+ * / `backups` / `backup_runs` directly, the same way `project-graph-test-helpers`
+ * seeds the project graph.
+ *
+ * Pair with `seedIdentity` (every row's `team_id` FK) + `seedServer` (a database's
+ * `server_id` RESTRICT FK), and drive the data functions inside
+ * `runWithIdentity({ userId, teamId })`.
+ *
+ * Not named `*.test.ts` so the `node --test` glob skips it (a helper).
+ */
+
+const T0 = "2026-01-01T00:00:00.000Z";
+
+/** Truncate every backups-cut-set table (call in `beforeEach` before seeding). */
+export const TRUNCATE_BACKUPS = `truncate table
+  backup_runs, backups, databases, s3_destination
+  restart identity cascade;`;
+
+export interface SeedDatabaseOpts {
+  id: string;
+  teamId?: string;
+  serverId?: string;
+  name?: string;
+  type?: Database["type"];
+  status?: Database["status"];
+}
+
+/** Seed one database row (its `connection_string_enc` is a real encrypted value). */
+export async function seedDatabase(
+  db: TestDb,
+  opts: SeedDatabaseOpts,
+): Promise<string> {
+  const type = opts.type ?? "postgres";
+  const name = opts.name ?? opts.id;
+  const row: Database = {
+    id: opts.id,
+    teamId: opts.teamId ?? TEAM_A,
+    name,
+    type,
+    version: "16",
+    status: opts.status ?? "running",
+    serverId: opts.serverId ?? SERVER_1,
+    host: `db-${name}`,
+    port: 5432,
+    connectionStringEnc: encryptSecret(
+      `postgres://app:pw@db-${name}:5432/db-${name}`,
+    ),
+    exposedPublicly: false,
+    sizeMb: 0,
+    createdAt: T0,
+  };
+  await db.insert(databasesTable).values(databaseToRow(row));
+  return row.id;
+}
+
+export interface SeedS3Opts {
+  id: string;
+  teamId?: string;
+  name?: string;
+  status?: S3Destination["status"];
+}
+
+/** Seed one S3 destination (real encrypted access/secret keys). */
+export async function seedS3(db: TestDb, opts: SeedS3Opts): Promise<string> {
+  const row: S3Destination = {
+    id: opts.id,
+    teamId: opts.teamId ?? TEAM_A,
+    name: opts.name ?? opts.id,
+    provider: "aws",
+    endpoint: "https://s3.us-east-1.amazonaws.com",
+    region: "us-east-1",
+    bucket: "deplo-backups",
+    accessKeyEnc: encryptSecret("AKIA_TEST"),
+    secretKeyEnc: encryptSecret("secret_test"),
+    status: opts.status ?? "connected",
+    createdAt: T0,
+  };
+  await db.insert(s3Table).values(s3ToRow(row));
+  return row.id;
+}
+
+export interface SeedBackupOpts {
+  id: string;
+  teamId?: string;
+  destinationId: string;
+  databaseId?: string | null;
+  projectId?: string | null;
+  targetKind?: Backup["targetKind"];
+  schedule?: string;
+  enabled?: boolean;
+  retentionDays?: number;
+}
+
+/** Seed one backup SCHEDULE. */
+export async function seedBackup(
+  db: TestDb,
+  opts: SeedBackupOpts,
+): Promise<string> {
+  const targetKind = opts.targetKind ?? "database";
+  const row: Backup = {
+    id: opts.id,
+    teamId: opts.teamId ?? TEAM_A,
+    name: opts.id,
+    targetKind,
+    databaseId: targetKind === "database" ? (opts.databaseId ?? null) : null,
+    projectId: targetKind === "project" ? (opts.projectId ?? null) : null,
+    destinationId: opts.destinationId,
+    schedule: opts.schedule ?? "0 3 * * *",
+    retentionDays: opts.retentionDays ?? 7,
+    lastRunAt: null,
+    lastStatus: "never",
+    enabled: opts.enabled ?? true,
+    createdAt: T0,
+  };
+  await db.insert(backupsTable).values(backupToRow(row));
+  return row.id;
+}
+
+export interface SeedRunOpts {
+  id: string;
+  teamId?: string;
+  backupId?: string | null;
+  destinationId: string;
+  databaseId?: string | null;
+  projectId?: string | null;
+  targetKind?: BackupRun["targetKind"];
+  status?: BackupRun["status"];
+  objectKey?: string;
+  startedAt?: string;
+  finishedAt?: string | null;
+}
+
+/** Seed one backup RUN (history). `seq` is DB-assigned in insert order. */
+export async function seedRun(db: TestDb, opts: SeedRunOpts): Promise<string> {
+  const targetKind = opts.targetKind ?? "database";
+  const row: BackupRun = {
+    id: opts.id,
+    teamId: opts.teamId ?? TEAM_A,
+    backupId: opts.backupId ?? null,
+    targetKind,
+    databaseId: targetKind === "database" ? (opts.databaseId ?? null) : null,
+    projectId: targetKind === "project" ? (opts.projectId ?? null) : null,
+    destinationId: opts.destinationId,
+    objectKey: opts.objectKey ?? `deplo/team_a/${targetKind}/t/${opts.id}.gz`,
+    sizeBytes: 1024,
+    status: opts.status ?? "success",
+    error: null,
+    startedAt: opts.startedAt ?? T0,
+    finishedAt: opts.finishedAt ?? T0,
+  };
+  await db.insert(backupRunsTable).values(backupRunToRow(row));
+  return row.id;
+}

--- a/lib/data/backups.test.ts
+++ b/lib/data/backups.test.ts
@@ -1,0 +1,247 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { PGlite } from "@electric-sql/pglite";
+import { eq } from "drizzle-orm";
+
+import { makeTestDb, type TestDb } from "../db/test-harness";
+import { __setTestDb, __resetTestDb } from "../db/client";
+import {
+  backups as backupsTable,
+  backupRuns as backupRunsTable,
+} from "../db/schema/control-plane";
+import { runWithIdentity } from "../auth/request-context";
+import { seedIdentity, TEAM_A, USER_1 } from "./identity-test-helpers";
+import { seedProject, seedServer } from "./project-graph-test-helpers";
+import {
+  seedBackup,
+  seedDatabase,
+  seedRun,
+  seedS3,
+  TRUNCATE_BACKUPS,
+} from "./backup-test-helpers";
+import {
+  backupDestinationsForTarget,
+  createBackup,
+  deleteBackup,
+  listBackupRuns,
+  reconcileInFlightBackupRuns,
+  runBackup,
+  toggleBackup,
+  updateBackup,
+} from "./backups";
+
+/**
+ * Data-layer tests for `backups` against pglite (PLAN Step 5, cut-set (d)). Covers
+ * the CRUD + validation (the target_kind XOR), the seq-ordered run list, the
+ * distinct-destinations sweep helper, the two-tx executor recording a `failed`
+ * run when it can't even resolve creds (no agent reached), and the boot reconcile
+ * that flips stale `running` runs (+ stuck schedules) to `failed`.
+ */
+
+let db: TestDb;
+let pg: PGlite;
+
+before(async () => {
+  ({ db, pg } = await makeTestDb());
+  __setTestDb(db);
+});
+
+after(async () => {
+  __resetTestDb();
+  await pg.close();
+});
+
+const T0 = "2026-01-01T00:00:00.000Z";
+
+beforeEach(async () => {
+  await pg.exec(`${TRUNCATE_BACKUPS}
+    truncate table project_build_method_settings, project_build, projects, servers,
+      users, teams restart identity cascade;`);
+  await seedIdentity(db, { users: [{ id: USER_1, teamId: TEAM_A, role: "owner" }] });
+  await seedServer(db);
+  await seedDatabase(db, { id: "db_1", name: "main" });
+  await seedProject(db, { id: "prj_1", teamId: TEAM_A });
+  await seedS3(db, { id: "s3_1" });
+});
+
+const asUser1 = <T>(fn: () => Promise<T>): Promise<T> =>
+  runWithIdentity({ userId: USER_1, teamId: TEAM_A }, fn);
+
+/* ------------------------------------------------------------------ */
+/* CRUD + validation                                                   */
+/* ------------------------------------------------------------------ */
+
+test("createBackup (database) inserts a schedule and resolves names in the DTO", async () => {
+  await asUser1(async () => {
+    const dto = await createBackup({
+      name: "nightly",
+      targetKind: "database",
+      databaseId: "db_1",
+      destinationId: "s3_1",
+      schedule: "0 3 * * *",
+      retentionDays: 7,
+    });
+    assert.equal(dto.targetKind, "database");
+    assert.equal(dto.databaseName, "main");
+    assert.equal(dto.projectName, null);
+    assert.equal(dto.destinationName, "s3_1");
+  });
+  // The row holds the XOR-consistent target (database set, project null).
+  const rows = await db.select().from(backupsTable);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]!.databaseId, "db_1");
+  assert.equal(rows[0]!.projectId, null);
+});
+
+test("createBackup (project) sets only the project target", async () => {
+  await asUser1(async () => {
+    const dto = await createBackup({
+      name: "prj-nightly",
+      targetKind: "project",
+      databaseId: null,
+      projectId: "prj_1",
+      destinationId: "s3_1",
+      schedule: "0 4 * * *",
+      retentionDays: 14,
+    });
+    assert.equal(dto.projectName, "prj_1");
+    assert.equal(dto.databaseName, null);
+  });
+  const rows = await db.select().from(backupsTable);
+  assert.equal(rows[0]!.projectId, "prj_1");
+  assert.equal(rows[0]!.databaseId, null);
+});
+
+test("createBackup rejects an unknown target / foreign destination", async () => {
+  await asUser1(async () => {
+    await assert.rejects(
+      () =>
+        createBackup({
+          name: "x", targetKind: "database", databaseId: "db_missing",
+          destinationId: "s3_1", schedule: "0 3 * * *", retentionDays: 7,
+        }),
+      /Database not found/,
+    );
+    await assert.rejects(
+      () =>
+        createBackup({
+          name: "x", targetKind: "database", databaseId: "db_1",
+          destinationId: "s3_missing", schedule: "0 3 * * *", retentionDays: 7,
+        }),
+      /Select a destination/,
+    );
+  });
+});
+
+test("toggleBackup / updateBackup / deleteBackup", async () => {
+  await seedBackup(db, { id: "bkp_1", destinationId: "s3_1", databaseId: "db_1" });
+  await seedS3(db, { id: "s3_2", name: "second" });
+  await asUser1(async () => {
+    await toggleBackup("bkp_1", false);
+    const updated = await updateBackup("bkp_1", {
+      name: "renamed", destinationId: "s3_2", schedule: "0 5 * * *", retentionDays: 30,
+    });
+    assert.equal(updated.name, "renamed");
+    assert.equal(updated.destinationName, "second");
+    assert.equal(updated.retentionDays, 30);
+  });
+  const row = (await db.select().from(backupsTable).where(eq(backupsTable.id, "bkp_1")))[0]!;
+  assert.equal(row.enabled, false);
+  assert.equal(row.schedule, "0 5 * * *");
+
+  await asUser1(() => deleteBackup("bkp_1"));
+  assert.equal((await db.select().from(backupsTable)).length, 0);
+});
+
+/* ------------------------------------------------------------------ */
+/* Run list ordering (seq tiebreak) + destination sweep                */
+/* ------------------------------------------------------------------ */
+
+test("listBackupRuns is newest-first by (startedAt, seq) — deterministic under a tie", async () => {
+  // Three runs at the SAME instant; insertion order (seq) decides newest-first.
+  await seedRun(db, { id: "r1", destinationId: "s3_1", databaseId: "db_1", startedAt: T0 });
+  await seedRun(db, { id: "r2", destinationId: "s3_1", databaseId: "db_1", startedAt: T0 });
+  await seedRun(db, { id: "r3", destinationId: "s3_1", databaseId: "db_1", startedAt: T0 });
+  await asUser1(async () => {
+    const runs = await listBackupRuns({ databaseId: "db_1" });
+    assert.deepEqual(runs.map((r) => r.id), ["r3", "r2", "r1"], "highest seq first");
+  });
+});
+
+test("backupDestinationsForTarget returns the distinct buckets a target ran to", async () => {
+  await seedS3(db, { id: "s3_2", name: "second" });
+  await seedRun(db, { id: "r1", destinationId: "s3_1", databaseId: "db_1" });
+  await seedRun(db, { id: "r2", destinationId: "s3_1", databaseId: "db_1" });
+  await seedRun(db, { id: "r3", destinationId: "s3_2", databaseId: "db_1" });
+  await asUser1(async () => {
+    const dests = await backupDestinationsForTarget({ kind: "database", targetId: "db_1" });
+    assert.deepEqual([...dests].sort(), ["s3_1", "s3_2"]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* The two-tx executor records start + terminal with no agent reached   */
+/* ------------------------------------------------------------------ */
+
+test("runBackup records a failed run when the owning agent is unreachable", async () => {
+  // A valid schedule against a real destination + database: the start tx persists
+  // a `running` run + stamps the schedule, the DB descriptor resolves with no
+  // network, then the agent dial fails (the seeded server has no live agent) →
+  // the terminal tx flips the run to `failed`. Proves BOTH short transactions run
+  // around the (failed) agent call, with the dial OUTSIDE either tx.
+  await seedBackup(db, { id: "bkp_1", destinationId: "s3_1", databaseId: "db_1" });
+  await asUser1(async () => {
+    await assert.rejects(() => runBackup("bkp_1"));
+    const runs = await listBackupRuns({ databaseId: "db_1" });
+    assert.equal(runs.length, 1, "the run was recorded (start tx)");
+    assert.equal(runs[0]!.status, "failed", "flipped failed (terminal tx)");
+    assert.ok(runs[0]!.finishedAt, "finishedAt stamped");
+  });
+  // The schedule's lastStatus settled to failed via the terminal transaction.
+  const b = (await db.select().from(backupsTable).where(eq(backupsTable.id, "bkp_1")))[0]!;
+  assert.equal(b.lastStatus, "failed");
+  assert.ok(b.lastRunAt, "lastRunAt stamped by the start tx");
+});
+
+/* ------------------------------------------------------------------ */
+/* Boot reconcile                                                       */
+/* ------------------------------------------------------------------ */
+
+test("reconcileInFlightBackupRuns flips stale running runs + stuck schedules to failed", async () => {
+  await seedBackup(db, { id: "bkp_1", destinationId: "s3_1", databaseId: "db_1" });
+  await db
+    .update(backupsTable)
+    .set({ lastStatus: "running" })
+    .where(eq(backupsTable.id, "bkp_1"));
+
+  // An OLD running run (orphaned by a restart) + a FRESH running run (genuinely
+  // in flight — must be left alone).
+  await seedRun(db, {
+    id: "r_old", destinationId: "s3_1", databaseId: "db_1", backupId: "bkp_1",
+    status: "running", startedAt: "2020-01-01T00:00:00.000Z", finishedAt: null,
+  });
+  await seedRun(db, {
+    id: "r_fresh", destinationId: "s3_1", databaseId: "db_1", backupId: "bkp_1",
+    status: "running", startedAt: new Date().toISOString(), finishedAt: null,
+  });
+
+  const n = await reconcileInFlightBackupRuns();
+  assert.equal(n, 1, "exactly the orphaned run reconciled");
+
+  const old = (await db.select().from(backupRunsTable).where(eq(backupRunsTable.id, "r_old")))[0]!;
+  assert.equal(old.status, "failed");
+  assert.ok(old.finishedAt, "finishedAt stamped");
+  const fresh = (await db.select().from(backupRunsTable).where(eq(backupRunsTable.id, "r_fresh")))[0]!;
+  assert.equal(fresh.status, "running", "a genuinely in-flight run is untouched");
+
+  const b = (await db.select().from(backupsTable).where(eq(backupsTable.id, "bkp_1")))[0]!;
+  assert.equal(b.lastStatus, "failed", "the stuck schedule settled");
+});
+
+test("reconcileInFlightBackupRuns is idempotent / a no-op with nothing stale", async () => {
+  await seedRun(db, {
+    id: "r1", destinationId: "s3_1", databaseId: "db_1", status: "success",
+  });
+  assert.equal(await reconcileInFlightBackupRuns(), 0);
+});

--- a/lib/data/backups.ts
+++ b/lib/data/backups.ts
@@ -1,6 +1,21 @@
 import "server-only";
 
-import { read, mutate } from "../store";
+import { and, desc, eq, inArray, lt } from "drizzle-orm";
+
+import { getDb } from "../db/client";
+import {
+  backups as backupsTable,
+  backupRuns as backupRunsTable,
+  databases as databasesTable,
+  s3Destination as s3DestinationTable,
+} from "../db/schema/control-plane";
+import {
+  assembleBackup,
+  assembleBackupRun,
+  assembleDatabase,
+  backupToRow,
+  backupRunToRow,
+} from "./backup-rows";
 import { getCurrentUser } from "../auth";
 import { newId, nowIso } from "../ids";
 import { requireActiveTeamId, requireCapability } from "../membership";
@@ -21,6 +36,7 @@ import {
   buildObjectKey,
   targetPrefix,
   selectDoomedRuns,
+  type RunForRetention,
 } from "./backup-objectkey";
 import { BackupKind } from "../agent/gen/agent";
 import type {
@@ -47,30 +63,76 @@ export interface BackupDTO extends Backup {
   destinationName: string;
 }
 
+/** Resolve the display name of a database by id (team-scoped), or null. */
+async function databaseNameFor(
+  id: string | null,
+  teamId: string,
+): Promise<string | null> {
+  if (!id) return null;
+  const rows = await getDb()
+    .select({ name: databasesTable.name })
+    .from(databasesTable)
+    .where(and(eq(databasesTable.id, id), eq(databasesTable.teamId, teamId)))
+    .limit(1);
+  return rows[0]?.name ?? null;
+}
+
+/** The owning server of a team's database `id`, or null. */
+async function databaseServerId(
+  id: string,
+  teamId: string,
+): Promise<string | null> {
+  const rows = await getDb()
+    .select({ serverId: databasesTable.serverId })
+    .from(databasesTable)
+    .where(and(eq(databasesTable.id, id), eq(databasesTable.teamId, teamId)))
+    .limit(1);
+  return rows[0]?.serverId ?? null;
+}
+
+/** Whether a team owns the S3 destination `id`. */
+async function destinationExists(id: string, teamId: string): Promise<boolean> {
+  const rows = await getDb()
+    .select({ id: s3DestinationTable.id })
+    .from(s3DestinationTable)
+    .where(and(eq(s3DestinationTable.id, id), eq(s3DestinationTable.teamId, teamId)))
+    .limit(1);
+  return rows.length > 0;
+}
+
+/** Resolve the display name of an S3 destination by id (team-scoped), or "". */
+async function destinationNameFor(id: string, teamId: string): Promise<string> {
+  const rows = await getDb()
+    .select({ name: s3DestinationTable.name })
+    .from(s3DestinationTable)
+    .where(and(eq(s3DestinationTable.id, id), eq(s3DestinationTable.teamId, teamId)))
+    .limit(1);
+  return rows[0]?.name ?? "";
+}
+
 async function toDTO(b: Backup): Promise<BackupDTO> {
-  const d = read();
-  // `databases`/`s3Destinations` stay JSONB (cut-set d); the project NAME is
-  // relational now (cut-set c) — look it up via the project graph.
+  // Every related collection is relational now: the database/destination names by
+  // point lookup, the project name via the project graph (cut-set c).
   const projectName = b.projectId
     ? ((await loadProjectGraph(b.projectId))?.name ?? null)
     : null;
   return {
     ...b,
-    databaseName: b.databaseId
-      ? (d.databases.find((x) => x.id === b.databaseId)?.name ?? null)
-      : null,
+    databaseName: await databaseNameFor(b.databaseId, b.teamId),
     projectName,
-    destinationName:
-      d.s3Destinations.find((x) => x.id === b.destinationId)?.name ?? "",
+    destinationName: await destinationNameFor(b.destinationId, b.teamId),
   };
 }
 
 export async function listBackups(): Promise<BackupDTO[]> {
   const teamId = await requireActiveTeamId();
-  const rows = read()
-    .backups.filter((b) => b.teamId === teamId)
-    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
-  return Promise.all(rows.map(toDTO));
+  // Newest-first sort pushed into SQL.
+  const rows = await getDb()
+    .select()
+    .from(backupsTable)
+    .where(eq(backupsTable.teamId, teamId))
+    .orderBy(desc(backupsTable.createdAt));
+  return Promise.all(rows.map((r) => toDTO(assembleBackup(r))));
 }
 
 export async function createBackup(input: {
@@ -94,16 +156,15 @@ export async function createBackup(input: {
 
   // The chosen destination + the target (database OR project) must belong to this
   // team. Exactly one target is set, matching `targetKind`.
-  const d0 = read();
-  if (!d0.s3Destinations.some((x) => x.id === input.destinationId && x.teamId === teamId))
+  if (!(await destinationExists(input.destinationId, teamId)))
     throw new Error("Select a destination");
   if (targetKind === "database") {
     if (!databaseId) throw new Error("Select a database to back up");
-    if (!d0.databases.some((x) => x.id === databaseId && x.teamId === teamId))
+    if (!(await databaseNameFor(databaseId, teamId)))
       throw new Error("Database not found");
   } else {
     if (!projectId) throw new Error("Select a project to back up");
-    if (!d0.projects.some((x) => x.id === projectId && x.teamId === teamId))
+    if (!(await loadTeamProject(projectId, teamId)))
       throw new Error("Project not found");
   }
 
@@ -122,7 +183,7 @@ export async function createBackup(input: {
     enabled: true,
     createdAt: nowIso(),
   };
-  mutate((d) => d.backups.push(b));
+  await getDb().insert(backupsTable).values(backupToRow(b));
   await recordActivity(
     "backup",
     `Created backup schedule ${b.name}`,
@@ -228,8 +289,13 @@ async function resolveTarget(
 ): Promise<ResolvedTarget> {
   if (kind === "database") {
     if (!databaseId) throw new Error("Backup has no database target");
-    const db = read().databases.find((x) => x.id === databaseId && x.teamId === teamId);
-    if (!db) throw new Error("Database not found");
+    const dbRows = await getDb()
+      .select()
+      .from(databasesTable)
+      .where(and(eq(databasesTable.id, databaseId), eq(databasesTable.teamId, teamId)))
+      .limit(1);
+    if (!dbRows[0]) throw new Error("Database not found");
+    const db = assembleDatabase(dbRows[0]);
     return {
       serverId: db.serverId,
       kind,
@@ -303,14 +369,17 @@ async function executeBackup(
     startedAt,
     finishedAt: null,
   };
-  mutate((d) => {
-    d.backupRuns.push(run);
+  // START transaction (short): persist the `running` run + stamp the owning
+  // schedule. This is the FIRST of the two short transactions; the long agent
+  // dump runs BETWEEN them, never inside a tx (PLAN §1 rule (a) — never hold a
+  // connection + locks across a gRPC call).
+  await getDb().transaction(async (tx) => {
+    await tx.insert(backupRunsTable).values(backupRunToRow(run));
     if (opts.backupId) {
-      const b = d.backups.find((x) => x.id === opts.backupId);
-      if (b) {
-        b.lastRunAt = startedAt;
-        b.lastStatus = "running";
-      }
+      await tx
+        .update(backupsTable)
+        .set({ lastRunAt: startedAt, lastStatus: "running" })
+        .where(eq(backupsTable.id, opts.backupId));
     }
   });
 
@@ -322,7 +391,7 @@ async function executeBackup(
   let failure: string | null = null;
   let objectKey = "";
   try {
-    const creds = getS3WithSecretsForTeam(teamId, opts.destinationId);
+    const creds = await getS3WithSecretsForTeam(teamId, opts.destinationId);
     const target = await resolveTarget(teamId, opts.kind, opts.databaseId, opts.projectId);
     label = target.label;
     activityProjectId = target.projectId;
@@ -335,11 +404,12 @@ async function executeBackup(
       at: new Date(startedAt),
     });
     // Record the resolved key on the running record now, so a crash mid-dump
-    // leaves the (single) object's key behind for a sweep.
-    mutate((d) => {
-      const r = d.backupRuns.find((x) => x.id === runId);
-      if (r) r.objectKey = objectKey;
-    });
+    // leaves the (single) object's key behind for a sweep. A single UPDATE —
+    // outside any transaction (the agent dump follows immediately).
+    await getDb()
+      .update(backupRunsTable)
+      .set({ objectKey })
+      .where(eq(backupRunsTable.id, runId));
 
     const req: BackupRequest = {
       kind: opts.kind === "database" ? BackupKind.BACKUP_KIND_DATABASE : BackupKind.BACKUP_KIND_PROJECT,
@@ -381,26 +451,31 @@ async function executeBackup(
   }
 
   const finishedAt = nowIso();
-  const finished = mutate((d): BackupRun => {
-    const r = d.backupRuns.find((x) => x.id === runId)!;
-    if (failure) {
-      r.status = "failed";
-      r.error = failure;
-    } else {
-      r.status = "success";
-      r.error = null;
-      r.objectKey = result!.objectKey;
-      r.sizeBytes = result!.sizeBytes;
-    }
-    r.finishedAt = finishedAt;
+  // TERMINAL transaction (short): flip the run to its final status + stamp the
+  // schedule. The SECOND of the two short transactions; the agent dump completed
+  // above, outside any tx (PLAN §1 rule (a)).
+  const finished = await getDb().transaction(async (tx): Promise<BackupRun> => {
+    const set = failure
+      ? { status: "failed" as const, error: failure, finishedAt }
+      : {
+          status: "success" as const,
+          error: null,
+          objectKey: result!.objectKey,
+          sizeBytes: result!.sizeBytes,
+          finishedAt,
+        };
+    const updated = await tx
+      .update(backupRunsTable)
+      .set(set)
+      .where(eq(backupRunsTable.id, runId))
+      .returning();
     if (opts.backupId) {
-      const b = d.backups.find((x) => x.id === opts.backupId);
-      if (b) {
-        b.lastRunAt = finishedAt;
-        b.lastStatus = failure ? "failed" : "success";
-      }
+      await tx
+        .update(backupsTable)
+        .set({ lastRunAt: finishedAt, lastStatus: failure ? "failed" : "success" })
+        .where(eq(backupsTable.id, opts.backupId));
     }
-    return { ...r };
+    return assembleBackupRun(updated[0]!);
   });
 
   await recordActivity(
@@ -442,14 +517,14 @@ async function pruneRetention(
   destinationId: string,
   retentionDays: number,
 ): Promise<void> {
-  const candidates = read().backupRuns.filter(
-    (r) =>
-      r.teamId === teamId &&
-      r.destinationId === destinationId &&
-      r.targetKind === target.kind &&
-      (target.kind === "database"
-        ? r.databaseId === target.databaseId
-        : r.projectId === target.projectId),
+  // Candidates carry their `seq` (the bigint identity) so `selectDoomedRuns` ranks
+  // newest-first by `(startedAt, seq)` — a same-millisecond tie ordered by
+  // timestamp alone could keep/delete the WRONG object (PLAN §5).
+  const candidates = await loadRunsForTarget(
+    teamId,
+    destinationId,
+    target.kind,
+    target.kind === "database" ? target.databaseId : target.projectId,
   );
   const doomed = selectDoomedRuns(candidates, {
     retentionDays,
@@ -465,7 +540,7 @@ async function pruneRetention(
   );
   const toDelete = doomed.filter((r) => r.status === "success" && r.objectKey);
   if (toDelete.length) {
-    const creds = getS3WithSecretsForTeam(teamId, destinationId);
+    const creds = await getS3WithSecretsForTeam(teamId, destinationId);
     const conn = await connectBackupAgent(target.serverId);
     try {
       for (const r of toDelete) {
@@ -491,9 +566,35 @@ async function pruneRetention(
   }
 
   if (removable.size === 0) return;
-  mutate((d) => {
-    d.backupRuns = d.backupRuns.filter((r) => !removable.has(r.id));
-  });
+  await getDb()
+    .delete(backupRunsTable)
+    .where(inArray(backupRunsTable.id, [...removable]));
+}
+
+/**
+ * Load a target's runs in ONE destination, carrying `seq` for retention ranking.
+ * Exactly one of `databaseId`/`projectId` is set (matching `kind`); team-scoped.
+ */
+async function loadRunsForTarget(
+  teamId: string,
+  destinationId: string,
+  kind: BackupTargetKind,
+  targetId: string | null,
+): Promise<RunForRetention[]> {
+  const rows = await getDb()
+    .select()
+    .from(backupRunsTable)
+    .where(
+      and(
+        eq(backupRunsTable.teamId, teamId),
+        eq(backupRunsTable.destinationId, destinationId),
+        eq(backupRunsTable.targetKind, kind),
+        kind === "database"
+          ? eq(backupRunsTable.databaseId, targetId ?? "")
+          : eq(backupRunsTable.projectId, targetId ?? ""),
+      ),
+    );
+  return rows.map((r) => ({ ...assembleBackupRun(r), seq: r.seq }));
 }
 
 /* ------------------------------------------------------------------ */
@@ -505,7 +606,7 @@ export async function runBackup(id: string): Promise<void> {
   const { membership } = await requireCapability("manage_infra");
   const teamId = membership.teamId;
   const user = (await getCurrentUser())!;
-  const b = read().backups.find((x) => x.id === id && x.teamId === teamId);
+  const b = await loadBackup(id, teamId);
   if (!b) throw new Error("Not found");
   await executeBackup(teamId, user.name, {
     backupId: b.id,
@@ -515,6 +616,16 @@ export async function runBackup(id: string): Promise<void> {
     destinationId: b.destinationId,
     retentionDays: b.retentionDays,
   });
+}
+
+/** Load one team-scoped backup schedule, assembled, or null. */
+async function loadBackup(id: string, teamId: string): Promise<Backup | null> {
+  const rows = await getDb()
+    .select()
+    .from(backupsTable)
+    .where(and(eq(backupsTable.id, id), eq(backupsTable.teamId, teamId)))
+    .limit(1);
+  return rows[0] ? assembleBackup(rows[0]) : null;
 }
 
 /**
@@ -558,10 +669,9 @@ export async function runProjectBackup(
   const { membership } = await requireCapability("manage_infra");
   const teamId = membership.teamId;
   const user = (await getCurrentUser())!;
-  const d0 = read();
-  if (!d0.projects.some((x) => x.id === projectId && x.teamId === teamId))
+  if (!(await loadTeamProject(projectId, teamId)))
     throw new Error("Project not found");
-  if (!d0.s3Destinations.some((x) => x.id === destinationId && x.teamId === teamId))
+  if (!(await destinationExists(destinationId, teamId)))
     throw new Error("Select a destination");
   return executeBackup(teamId, user.name, {
     backupId: null,
@@ -585,12 +695,17 @@ export async function restoreBackup(runId: string): Promise<void> {
   const teamId = membership.teamId;
   const user = (await getCurrentUser())!;
 
-  const run = read().backupRuns.find((r) => r.id === runId && r.teamId === teamId);
-  if (!run) throw new Error("Backup run not found");
+  const runRows = await getDb()
+    .select()
+    .from(backupRunsTable)
+    .where(and(eq(backupRunsTable.id, runId), eq(backupRunsTable.teamId, teamId)))
+    .limit(1);
+  if (!runRows[0]) throw new Error("Backup run not found");
+  const run = assembleBackupRun(runRows[0]);
   if (run.status !== "success")
     throw new Error("This backup did not complete successfully and cannot be restored");
 
-  const creds = getS3WithSecretsForTeam(teamId, run.destinationId);
+  const creds = await getS3WithSecretsForTeam(teamId, run.destinationId);
   const target = await resolveTarget(
     teamId,
     run.targetKind,
@@ -643,17 +758,21 @@ export async function listBackupRuns(filter: {
   databaseId?: string;
 }): Promise<BackupRun[]> {
   const teamId = await requireActiveTeamId();
-  return read()
-    .backupRuns.filter(
-      (r) =>
-        r.teamId === teamId &&
-        (filter.projectId
-          ? r.projectId === filter.projectId
-          : filter.databaseId
-            ? r.databaseId === filter.databaseId
-            : false),
-    )
-    .sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1));
+  // Exactly one of projectId/databaseId selects the target; neither ⇒ no runs.
+  const targetWhere = filter.projectId
+    ? eq(backupRunsTable.projectId, filter.projectId)
+    : filter.databaseId
+      ? eq(backupRunsTable.databaseId, filter.databaseId)
+      : null;
+  if (!targetWhere) return [];
+  // Newest-first by (started_at, seq) DESC, pushed into SQL (matches
+  // backup_runs_team_started_idx) — deterministic under a same-ms tie (PLAN §5).
+  const rows = await getDb()
+    .select()
+    .from(backupRunsTable)
+    .where(and(eq(backupRunsTable.teamId, teamId), targetWhere))
+    .orderBy(desc(backupRunsTable.startedAt), desc(backupRunsTable.seq));
+  return rows.map(assembleBackupRun);
 }
 
 export async function toggleBackup(
@@ -661,11 +780,12 @@ export async function toggleBackup(
   enabled: boolean,
 ): Promise<void> {
   const teamId = (await requireCapability("manage_infra")).teamId;
-  mutate((d) => {
-    const b = d.backups.find((x) => x.id === id && x.teamId === teamId);
-    if (!b) throw new Error("Not found");
-    b.enabled = enabled;
-  });
+  const updated = await getDb()
+    .update(backupsTable)
+    .set({ enabled })
+    .where(and(eq(backupsTable.id, id), eq(backupsTable.teamId, teamId)))
+    .returning({ id: backupsTable.id });
+  if (updated.length === 0) throw new Error("Not found");
 }
 
 /**
@@ -691,38 +811,36 @@ export async function updateBackup(
   if (!input.destinationId) throw new Error("Select a destination");
 
   // The (possibly changed) destination must belong to this team.
-  if (
-    !read().s3Destinations.some(
-      (x) => x.id === input.destinationId && x.teamId === teamId,
-    )
-  )
+  if (!(await destinationExists(input.destinationId, teamId)))
     throw new Error("Select a destination");
 
-  let updated: Backup | undefined;
-  mutate((d) => {
-    const b = d.backups.find((x) => x.id === id && x.teamId === teamId);
-    if (!b) throw new Error("Not found");
-    b.name = input.name.trim();
-    b.destinationId = input.destinationId;
-    b.schedule = input.schedule || "0 3 * * *";
-    b.retentionDays = Math.max(1, input.retentionDays || 7);
-    updated = b;
-  });
+  const updated = await getDb()
+    .update(backupsTable)
+    .set({
+      name: input.name.trim(),
+      destinationId: input.destinationId,
+      schedule: input.schedule || "0 3 * * *",
+      retentionDays: Math.max(1, input.retentionDays || 7),
+    })
+    .where(and(eq(backupsTable.id, id), eq(backupsTable.teamId, teamId)))
+    .returning();
+  if (updated.length === 0) throw new Error("Not found");
+  const b = assembleBackup(updated[0]!);
   await recordActivity(
     "backup",
-    `Updated backup schedule ${updated!.name}`,
+    `Updated backup schedule ${b.name}`,
     user.name,
     null,
     teamId,
   );
-  return await toDTO(updated!);
+  return await toDTO(b);
 }
 
 export async function deleteBackup(id: string): Promise<void> {
   const teamId = (await requireCapability("manage_infra")).teamId;
-  mutate((d) => {
-    d.backups = d.backups.filter((x) => !(x.id === id && x.teamId === teamId));
-  });
+  await getDb()
+    .delete(backupsTable)
+    .where(and(eq(backupsTable.id, id), eq(backupsTable.teamId, teamId)));
 }
 
 /**
@@ -745,9 +863,10 @@ export async function deleteBackupArtifacts(input: {
   serverId: string;
 }): Promise<number> {
   const teamId = await requireActiveTeamId();
-  const creds = getS3WithSecretsForTeam(teamId, input.destinationId);
+  const creds = await getS3WithSecretsForTeam(teamId, input.destinationId);
   const prefix = targetPrefix(teamId, input.kind, input.targetId);
 
+  // The prefix-delete (RPC) runs BEFORE the record delete — outside any tx.
   let deleted = 0;
   const conn = await connectBackupAgent(input.serverId);
   try {
@@ -757,20 +876,28 @@ export async function deleteBackupArtifacts(input: {
     conn.close();
   }
 
-  mutate((d) => {
-    d.backupRuns = d.backupRuns.filter(
-      (r) =>
-        !(
-          r.teamId === teamId &&
-          r.destinationId === input.destinationId &&
-          r.targetKind === input.kind &&
-          (input.kind === "database"
-            ? r.databaseId === input.targetId
-            : r.projectId === input.targetId)
-        ),
+  // Drop the run records for THIS target in THIS destination (the bucket we just
+  // swept) — records in other destinations (whose objects survive) stay.
+  await getDb()
+    .delete(backupRunsTable)
+    .where(
+      and(
+        eq(backupRunsTable.teamId, teamId),
+        eq(backupRunsTable.destinationId, input.destinationId),
+        runTargetWhere(input.kind, input.targetId),
+      ),
     );
-  });
   return deleted;
+}
+
+/** The `backup_runs` WHERE clause selecting one target (database OR project). */
+function runTargetWhere(kind: BackupTargetKind, targetId: string) {
+  return and(
+    eq(backupRunsTable.targetKind, kind),
+    kind === "database"
+      ? eq(backupRunsTable.databaseId, targetId)
+      : eq(backupRunsTable.projectId, targetId),
+  )!;
 }
 
 /**
@@ -783,19 +910,13 @@ export async function backupDestinationsForTarget(input: {
   targetId: string;
 }): Promise<string[]> {
   const teamId = await requireActiveTeamId();
-  const ids = new Set<string>();
-  for (const r of read().backupRuns) {
-    if (
-      r.teamId === teamId &&
-      r.targetKind === input.kind &&
-      (input.kind === "database"
-        ? r.databaseId === input.targetId
-        : r.projectId === input.targetId)
-    ) {
-      ids.add(r.destinationId);
-    }
-  }
-  return [...ids];
+  const rows = await getDb()
+    .selectDistinct({ destinationId: backupRunsTable.destinationId })
+    .from(backupRunsTable)
+    .where(
+      and(eq(backupRunsTable.teamId, teamId), runTargetWhere(input.kind, input.targetId)),
+    );
+  return rows.map((r) => r.destinationId);
 }
 
 /**
@@ -832,9 +953,7 @@ export async function deleteAllBackupArtifacts(input: {
   // delete objects). A missing/foreign row yields no server and nothing to do.
   const serverId =
     input.kind === "database"
-      ? (read().databases.find(
-          (x) => x.id === input.targetId && x.teamId === teamId,
-        )?.serverId ?? null)
+      ? ((await databaseServerId(input.targetId, teamId)) ?? null)
       : ((await loadTeamProject(input.targetId, teamId))?.serverId ?? null);
 
   const destinations = await backupDestinationsForTarget(input);
@@ -844,18 +963,14 @@ export async function deleteAllBackupArtifacts(input: {
     // owning agent left to reach the buckets. Drop the orphaned records so history
     // matches reality, and report the destinations as failed (their objects can't
     // be swept from here) so the caller doesn't claim a clean wipe.
-    mutate((d) => {
-      d.backupRuns = d.backupRuns.filter(
-        (r) =>
-          !(
-            r.teamId === teamId &&
-            r.targetKind === input.kind &&
-            (input.kind === "database"
-              ? r.databaseId === input.targetId
-              : r.projectId === input.targetId)
-          ),
+    await getDb()
+      .delete(backupRunsTable)
+      .where(
+        and(
+          eq(backupRunsTable.teamId, teamId),
+          runTargetWhere(input.kind, input.targetId),
+        ),
       );
-    });
     return { deleted: 0, failedDestinations: destinations };
   }
 
@@ -899,27 +1014,44 @@ const RUN_ORPHAN_AFTER_MS = 90 * 60_000;
  * {@link RUN_ORPHAN_AFTER_MS}, so it can never race a genuinely in-flight run.
  * Returns how many it reconciled.
  */
-export function reconcileInFlightBackupRuns(): number {
-  const cutoff = Date.now() - RUN_ORPHAN_AFTER_MS;
-  let reconciled = 0;
+export async function reconcileInFlightBackupRuns(): Promise<number> {
+  const cutoffIso = new Date(Date.now() - RUN_ORPHAN_AFTER_MS).toISOString();
   const finishedAt = nowIso();
-  mutate((d) => {
-    const orphanedBackupIds = new Set<string>();
-    for (const r of d.backupRuns) {
-      if (r.status === "running" && new Date(r.startedAt).getTime() < cutoff) {
-        r.status = "failed";
-        r.error = "Interrupted by a control-plane restart and marked failed.";
-        r.finishedAt = finishedAt;
-        reconciled++;
-        if (r.backupId) orphanedBackupIds.add(r.backupId);
-      }
-    }
+  const reconciled = await getDb().transaction(async (tx) => {
+    // Flip stale `running` runs to `failed` (the partial index
+    // `backup_runs_running_idx` serves this). RETURNING their owning schedule ids
+    // so the second statement can settle those schedules.
+    const flipped = await tx
+      .update(backupRunsTable)
+      .set({
+        status: "failed",
+        error: "Interrupted by a control-plane restart and marked failed.",
+        finishedAt,
+      })
+      .where(
+        and(
+          eq(backupRunsTable.status, "running"),
+          lt(backupRunsTable.startedAt, cutoffIso),
+        ),
+      )
+      .returning({ backupId: backupRunsTable.backupId });
+
+    const orphanedBackupIds = [
+      ...new Set(flipped.map((r) => r.backupId).filter((id): id is string => !!id)),
+    ];
     // A schedule stuck on `lastStatus:"running"` for an orphaned run settles too.
-    for (const b of d.backups) {
-      if (b.lastStatus === "running" && orphanedBackupIds.has(b.id)) {
-        b.lastStatus = "failed";
-      }
+    if (orphanedBackupIds.length > 0) {
+      await tx
+        .update(backupsTable)
+        .set({ lastStatus: "failed" })
+        .where(
+          and(
+            eq(backupsTable.lastStatus, "running"),
+            inArray(backupsTable.id, orphanedBackupIds),
+          ),
+        );
     }
+    return flipped.length;
   });
   if (reconciled > 0) {
     console.warn(

--- a/lib/data/databases.test.ts
+++ b/lib/data/databases.test.ts
@@ -1,0 +1,124 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { PGlite } from "@electric-sql/pglite";
+import { eq } from "drizzle-orm";
+
+import { makeTestDb, type TestDb } from "../db/test-harness";
+import { __setTestDb, __resetTestDb } from "../db/client";
+import {
+  backups as backupsTable,
+  backupRuns as backupRunsTable,
+  databases as databasesTable,
+} from "../db/schema/control-plane";
+import { runWithIdentity } from "../auth/request-context";
+import { seedIdentity, TEAM_A, TEAM_B, USER_1 } from "./identity-test-helpers";
+import { seedServer } from "./project-graph-test-helpers";
+import { seedBackup, seedDatabase, seedRun, seedS3, TRUNCATE_BACKUPS } from "./backup-test-helpers";
+import {
+  getConnectionString,
+  getDatabase,
+  listDatabases,
+  deleteDatabase,
+} from "./databases";
+
+/**
+ * Data-layer tests for `databases` against pglite (PLAN Step 5, cut-set (d)).
+ * Verifies the newest-first SQL list, team isolation, the masked DTO / decrypted
+ * connection string, and — the headline — that `deleteDatabase` removes the row
+ * with the agent teardown OUTSIDE the delete, and the DB FKs CASCADE dependent
+ * backup schedules + SET NULL a run's databaseId (the orphan the JSONB version
+ * hand-filtered).
+ */
+
+let db: TestDb;
+let pg: PGlite;
+
+before(async () => {
+  ({ db, pg } = await makeTestDb());
+  __setTestDb(db);
+});
+
+after(async () => {
+  __resetTestDb();
+  await pg.close();
+});
+
+beforeEach(async () => {
+  await pg.exec(`${TRUNCATE_BACKUPS}
+    truncate table users, teams restart identity cascade;`);
+  await seedIdentity(db, {
+    users: [
+      { id: USER_1, teamId: TEAM_A, role: "owner" },
+      { id: "user_2", teamId: TEAM_B, role: "owner" },
+    ],
+  });
+  await seedServer(db);
+});
+
+const asUser1 = <T>(fn: () => Promise<T>): Promise<T> =>
+  runWithIdentity({ userId: USER_1, teamId: TEAM_A }, fn);
+
+test("listDatabases is team-scoped, newest-first, and masks the connection string", async () => {
+  await seedDatabase(db, { id: "db_old", name: "old" });
+  // A newer row (later createdAt) must sort first.
+  await db
+    .update(databasesTable)
+    .set({ createdAt: "2026-02-01T00:00:00.000Z" })
+    .where(eq(databasesTable.id, "db_old"));
+  await seedDatabase(db, { id: "db_new", name: "new" });
+  await db
+    .update(databasesTable)
+    .set({ createdAt: "2026-03-01T00:00:00.000Z" })
+    .where(eq(databasesTable.id, "db_new"));
+  // A foreign-team database is invisible.
+  await seedDatabase(db, { id: "db_other", teamId: TEAM_B, name: "other" });
+
+  await asUser1(async () => {
+    const list = await listDatabases();
+    assert.deepEqual(list.map((d) => d.id), ["db_new", "db_old"]);
+    assert.equal("connectionStringEnc" in list[0]!, false, "no secret in the DTO");
+    assert.ok(list[0]!.connectionStringMasked.includes("••••"), "password masked");
+  });
+});
+
+test("getConnectionString decrypts; getDatabase is team-scoped", async () => {
+  await seedDatabase(db, { id: "db_1", name: "main" });
+  await asUser1(async () => {
+    const conn = await getConnectionString("db_1");
+    assert.ok(conn.startsWith("postgres://"), "decrypted plaintext");
+    assert.ok((await getDatabase("db_1")) !== null);
+  });
+  // user_2 (team B) cannot see team A's database.
+  await runWithIdentity({ userId: "user_2", teamId: TEAM_B }, async () => {
+    assert.equal(await getDatabase("db_1"), null);
+    await assert.rejects(() => getConnectionString("db_1"), /Not found/);
+  });
+});
+
+test("deleteDatabase cascades schedules and SET NULLs run history (no orphans)", async () => {
+  await seedDatabase(db, { id: "db_1", name: "main" });
+  const s3 = await seedS3(db, { id: "s3_1" });
+  // A schedule targeting the db (CASCADE) + a run referencing it (SET NULL).
+  await seedBackup(db, { id: "bkp_1", destinationId: s3, databaseId: "db_1" });
+  await seedRun(db, { id: "brun_1", destinationId: s3, databaseId: "db_1", backupId: "bkp_1" });
+
+  // The seeded server has no live agent, so the teardown dial fails — best-effort:
+  // the row is still deleted (and an orphan warning logged). This also proves the
+  // agent call is OUTSIDE the delete (a thrown dial can't roll the delete back).
+  await asUser1(() => deleteDatabase("db_1"));
+
+  assert.equal(
+    (await db.select().from(databasesTable).where(eq(databasesTable.id, "db_1"))).length,
+    0,
+    "database row deleted",
+  );
+  assert.equal(
+    (await db.select().from(backupsTable).where(eq(backupsTable.id, "bkp_1"))).length,
+    0,
+    "dependent schedule CASCADE-deleted",
+  );
+  const run = await db.select().from(backupRunsTable).where(eq(backupRunsTable.id, "brun_1"));
+  assert.equal(run.length, 1, "run history survives");
+  assert.equal(run[0]!.databaseId, null, "run.databaseId SET NULL");
+});

--- a/lib/data/databases.ts
+++ b/lib/data/databases.ts
@@ -1,6 +1,11 @@
 import "server-only";
 
-import { read, mutate } from "../store";
+import { and, desc, eq } from "drizzle-orm";
+
+import { read } from "../store";
+import { getDb } from "../db/client";
+import { databases as databasesTable } from "../db/schema/control-plane";
+import { assembleDatabase, databaseToRow } from "./backup-rows";
 import { getCurrentUser } from "../auth";
 import { newId, nowIso } from "../ids";
 import { requireActiveTeamId, requireCapability } from "../membership";
@@ -48,23 +53,39 @@ function toDTO(db: Database): DatabaseDTO {
   };
 }
 
+/** Load one team-scoped database row, assembled, or null. */
+async function loadDatabase(
+  id: string,
+  teamId: string,
+): Promise<Database | null> {
+  const rows = await getDb()
+    .select()
+    .from(databasesTable)
+    .where(and(eq(databasesTable.id, id), eq(databasesTable.teamId, teamId)))
+    .limit(1);
+  return rows[0] ? assembleDatabase(rows[0]) : null;
+}
+
 export async function listDatabases(): Promise<DatabaseDTO[]> {
   const teamId = await requireActiveTeamId();
-  return read()
-    .databases.filter((d) => d.teamId === teamId)
-    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
-    .map(toDTO);
+  // Newest-first sort pushed into SQL.
+  const rows = await getDb()
+    .select()
+    .from(databasesTable)
+    .where(eq(databasesTable.teamId, teamId))
+    .orderBy(desc(databasesTable.createdAt));
+  return rows.map((r) => toDTO(assembleDatabase(r)));
 }
 
 export async function getDatabase(id: string): Promise<DatabaseDTO | null> {
   const teamId = await requireActiveTeamId();
-  const db = read().databases.find((x) => x.id === id && x.teamId === teamId);
+  const db = await loadDatabase(id, teamId);
   return db ? toDTO(db) : null;
 }
 
 export async function getConnectionString(id: string): Promise<string> {
   const teamId = await requireActiveTeamId();
-  const db = read().databases.find((x) => x.id === id && x.teamId === teamId);
+  const db = await loadDatabase(id, teamId);
   if (!db) throw new Error("Not found");
   return decryptSecret(db.connectionStringEnc);
 }
@@ -129,7 +150,7 @@ export async function createDatabase(input: {
     sizeMb: 0,
     createdAt: nowIso(),
   };
-  mutate((d) => d.databases.push(db));
+  await getDb().insert(databasesTable).values(databaseToRow(db));
   await recordActivity("database", `Created database ${name} (${input.type})`, user.name, null);
 
   // Provision the real container on the owning server's agent in the background;
@@ -140,14 +161,16 @@ export async function createDatabase(input: {
     version: input.version,
     password,
     exposePort: input.exposedPublicly ?? false,
-  }).catch(() => {
-    mutate((d) => {
-      const x = d.databases.find((y) => y.id === db.id);
-      if (x) x.status = "error";
-    });
+  }).catch(async () => {
+    // Mark the row errored — but only if it still exists (a concurrent delete may
+    // have raced the floated provision; an UPDATE matching no row is a safe no-op).
+    await getDb()
+      .update(databasesTable)
+      .set({ status: "error" })
+      .where(eq(databasesTable.id, db.id));
   });
 
-  return toDTO(read().databases.find((x) => x.id === db.id)!);
+  return toDTO(db);
 }
 
 /**
@@ -182,7 +205,7 @@ async function provisionDatabase(
   // acquired the lock, there is nothing to provision — bail without creating a
   // stack the control plane no longer tracks.
   await withKeyedLock(id, async () => {
-    if (!read().databases.some((x) => x.id === id)) return; // deleted before us
+    if (!(await databaseExists(id))) return; // deleted before us
     const conn = await connectAgent(serverId);
     try {
       const res = await conn.reroute({
@@ -195,11 +218,23 @@ async function provisionDatabase(
     } finally {
       conn.close();
     }
-    mutate((d) => {
-      const db = d.databases.find((x) => x.id === id);
-      if (db) db.status = "running";
-    });
+    // A single UPDATE; if the row was deleted while the agent provisioned (under
+    // the lock this can't happen, but the UPDATE is a safe no-op regardless).
+    await getDb()
+      .update(databasesTable)
+      .set({ status: "running" })
+      .where(eq(databasesTable.id, id));
   });
+}
+
+/** Whether a database row still exists (id-only existence probe, not team-scoped). */
+async function databaseExists(id: string): Promise<boolean> {
+  const rows = await getDb()
+    .select({ id: databasesTable.id })
+    .from(databasesTable)
+    .where(eq(databasesTable.id, id))
+    .limit(1);
+  return rows.length > 0;
 }
 
 export async function setDatabaseRunning(
@@ -207,7 +242,7 @@ export async function setDatabaseRunning(
   running: boolean
 ): Promise<void> {
   const teamId = (await requireCapability("manage_infra")).teamId;
-  const db = read().databases.find((x) => x.id === id && x.teamId === teamId);
+  const db = await loadDatabase(id, teamId);
   if (!db) throw new Error("Not found");
   const host = db.host;
   const serverId = db.serverId;
@@ -218,7 +253,7 @@ export async function setDatabaseRunning(
   await withKeyedLock(id, async () => {
     // Re-read under the lock — the DB may have been deleted, or just finished
     // provisioning, while we waited our turn.
-    const cur = read().databases.find((x) => x.id === id && x.teamId === teamId);
+    const cur = await loadDatabase(id, teamId);
     if (!cur) throw new Error("Not found");
     // The compose project doesn't exist until provisioning finishes, so start/stop
     // against a still-provisioning DB would fail on the agent with a confusing
@@ -241,19 +276,17 @@ export async function setDatabaseRunning(
     } finally {
       conn.close();
     }
-    mutate((d) => {
-      const x = d.databases.find((y) => y.id === id);
-      if (x) x.status = running ? "running" : "stopped";
-    });
+    await getDb()
+      .update(databasesTable)
+      .set({ status: running ? "running" : "stopped" })
+      .where(eq(databasesTable.id, id));
   });
 }
 
 export async function deleteDatabase(id: string): Promise<void> {
   const { membership } = await requireCapability("manage_infra");
   const user = (await getCurrentUser())!;
-  const db = read().databases.find(
-    (x) => x.id === id && x.teamId === membership.teamId,
-  );
+  const db = await loadDatabase(id, membership.teamId);
   if (!db) throw new Error("Not found");
   // Serialize the whole teardown on the DB's lifecycle lock. The race this closes:
   // createDatabase fires provisionDatabase (`compose up -d`) as a floated task, so
@@ -264,7 +297,7 @@ export async function deleteDatabase(id: string): Promise<void> {
   await withKeyedLock(id, async () => {
     // Re-check under the lock: a concurrent delete (or never-finished provision
     // that bailed) may have already removed the row. Idempotent → just return.
-    if (!read().databases.some((x) => x.id === id)) return;
+    if (!(await databaseExists(id))) return;
     // Tear down the real container + data volume on the owning agent via
     // `removeVolumes` (`down -v` + remove the compose file). Best-effort: we still
     // remove the row (the operator asked to delete it) even when the volume could
@@ -296,10 +329,11 @@ export async function deleteDatabase(id: string): Promise<void> {
         `need a manual cleanup on the host.`;
     }
     if (orphanWarning) console.warn(`[databases] ${orphanWarning}`);
-    mutate((d) => {
-      d.databases = d.databases.filter((x) => x.id !== id);
-      d.backups = d.backups.filter((b) => b.databaseId !== id);
-    });
+    // One DELETE — the agent teardown above ran OUTSIDE any transaction (PLAN §1
+    // rule (a)). The `backups.database_id` FK CASCADE removes dependent backup
+    // SCHEDULES automatically (was a manual `d.backups` filter); `backup_runs`'
+    // `database_id` is SET NULL so run history outlives the deleted database.
+    await getDb().delete(databasesTable).where(eq(databasesTable.id, id));
     await recordActivity(
       "database",
       orphanWarning

--- a/lib/data/s3.test.ts
+++ b/lib/data/s3.test.ts
@@ -1,0 +1,139 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { PGlite } from "@electric-sql/pglite";
+import { eq } from "drizzle-orm";
+
+import { makeTestDb, type TestDb } from "../db/test-harness";
+import { __setTestDb, __resetTestDb } from "../db/client";
+import {
+  backups as backupsTable,
+  backupRuns as backupRunsTable,
+  s3Destination as s3Table,
+} from "../db/schema/control-plane";
+import { runWithIdentity } from "../auth/request-context";
+import { decryptSecret } from "../crypto";
+import { seedIdentity, TEAM_A, TEAM_B, USER_1 } from "./identity-test-helpers";
+import { seedServer } from "./project-graph-test-helpers";
+import {
+  seedBackup,
+  seedDatabase,
+  seedRun,
+  seedS3,
+  TRUNCATE_BACKUPS,
+} from "./backup-test-helpers";
+import { createS3, deleteS3, getS3WithSecrets, listS3 } from "./s3";
+
+/**
+ * Data-layer tests for `s3` against pglite (PLAN Step 5, cut-set (d)). Verifies the
+ * newest-first SQL list, the masked DTO + decrypted creds for the executor, team
+ * isolation, and that `deleteS3` removes dependent backup schedules AND run history
+ * in ONE transaction (the `destination_id` FK is RESTRICT, so the dependents are
+ * deleted explicitly — never cascade-orphaned).
+ */
+
+let db: TestDb;
+let pg: PGlite;
+
+before(async () => {
+  ({ db, pg } = await makeTestDb());
+  __setTestDb(db);
+});
+
+after(async () => {
+  __resetTestDb();
+  await pg.close();
+});
+
+beforeEach(async () => {
+  await pg.exec(`${TRUNCATE_BACKUPS}
+    truncate table users, teams restart identity cascade;`);
+  await seedIdentity(db, {
+    users: [
+      { id: USER_1, teamId: TEAM_A, role: "owner" },
+      { id: "user_2", teamId: TEAM_B, role: "owner" },
+    ],
+  });
+  await seedServer(db);
+});
+
+const asUser1 = <T>(fn: () => Promise<T>): Promise<T> =>
+  runWithIdentity({ userId: USER_1, teamId: TEAM_A }, fn);
+
+test("createS3 stores encrypted creds; the DTO masks them and starts unverified", async () => {
+  await asUser1(async () => {
+    const dto = await createS3({
+      name: "Backblaze",
+      provider: "backblaze-b2",
+      endpoint: "https://s3.eu.backblazeb2.com",
+      region: "eu",
+      bucket: "deplo",
+      accessKey: "AKIA",
+      secretKey: "s3cret",
+    });
+    assert.equal(dto.status, "unverified");
+    assert.equal(dto.accessKeyMasked, "••••••••");
+    assert.equal("accessKeyEnc" in dto, false);
+    assert.equal("secretKeyEnc" in dto, false);
+  });
+  // The stored row holds ciphertext, decryptable by the executor seam.
+  await asUser1(async () => {
+    const list = await listS3();
+    const creds = await getS3WithSecrets(list[0]!.id);
+    assert.equal(creds.accessKey, "AKIA");
+    assert.equal(creds.secretKey, "s3cret");
+  });
+  // The raw row never holds the plaintext.
+  const rows = await db.select().from(s3Table);
+  assert.notEqual(decryptSecret(rows[0]!.accessKeyEnc), "");
+  assert.notEqual(rows[0]!.accessKeyEnc, "AKIA");
+});
+
+test("listS3 is team-scoped and newest-first", async () => {
+  await seedS3(db, { id: "s3_a", name: "a" });
+  await db
+    .update(s3Table)
+    .set({ createdAt: "2026-02-01T00:00:00.000Z" })
+    .where(eq(s3Table.id, "s3_a"));
+  await seedS3(db, { id: "s3_b", name: "b" });
+  await db
+    .update(s3Table)
+    .set({ createdAt: "2026-03-01T00:00:00.000Z" })
+    .where(eq(s3Table.id, "s3_b"));
+  await seedS3(db, { id: "s3_other", teamId: TEAM_B, name: "other" });
+
+  await asUser1(async () => {
+    const list = await listS3();
+    assert.deepEqual(list.map((s) => s.id), ["s3_b", "s3_a"]);
+  });
+});
+
+test("deleteS3 removes dependent schedules AND run history in one transaction", async () => {
+  await seedDatabase(db, { id: "db_1" });
+  await seedS3(db, { id: "s3_1" });
+  await seedBackup(db, { id: "bkp_1", destinationId: "s3_1", databaseId: "db_1" });
+  await seedRun(db, { id: "brun_1", destinationId: "s3_1", databaseId: "db_1", backupId: "bkp_1" });
+
+  await asUser1(() => deleteS3("s3_1"));
+
+  assert.equal((await db.select().from(s3Table).where(eq(s3Table.id, "s3_1"))).length, 0);
+  assert.equal(
+    (await db.select().from(backupsTable).where(eq(backupsTable.destinationId, "s3_1"))).length,
+    0,
+    "dependent schedule removed (RESTRICT FK ⇒ explicit delete)",
+  );
+  assert.equal(
+    (await db.select().from(backupRunsTable).where(eq(backupRunsTable.destinationId, "s3_1"))).length,
+    0,
+    "dependent run history removed (no dangling destinationId)",
+  );
+});
+
+test("deleteS3 is team-scoped (a foreign destination is not found)", async () => {
+  await seedS3(db, { id: "s3_b", teamId: TEAM_B });
+  await asUser1(async () => {
+    await assert.rejects(() => deleteS3("s3_b"), /Not found/);
+  });
+  // Still present.
+  assert.equal((await db.select().from(s3Table).where(eq(s3Table.id, "s3_b"))).length, 1);
+});

--- a/lib/data/s3.ts
+++ b/lib/data/s3.ts
@@ -1,6 +1,15 @@
 import "server-only";
 
-import { read, mutate } from "../store";
+import { and, desc, eq } from "drizzle-orm";
+
+import { read } from "../store";
+import { getDb } from "../db/client";
+import {
+  backups as backupsTable,
+  backupRuns as backupRunsTable,
+  s3Destination as s3Table,
+} from "../db/schema/control-plane";
+import { assembleS3, s3ToRow } from "./backup-rows";
 import { getCurrentUser } from "../auth";
 import { newId, nowIso } from "../ids";
 import { requireActiveTeamId, requireCapability } from "../membership";
@@ -66,17 +75,27 @@ export interface S3WithSecrets {
  * context, so it must call this with the schedule's own `teamId` rather than the
  * cookie-derived active team; the interactive {@link getS3WithSecrets} wraps it.
  */
-export function getS3WithSecretsForTeam(
+export async function getS3WithSecretsForTeam(
   teamId: string,
   id: string,
-): S3WithSecrets {
-  const s = read().s3Destinations.find((x) => x.id === id && x.teamId === teamId);
+): Promise<S3WithSecrets> {
+  const s = await loadS3(id, teamId);
   if (!s) throw new Error("Destination not found");
   return {
     destination: s,
     accessKey: decryptSecret(s.accessKeyEnc),
     secretKey: decryptSecret(s.secretKeyEnc),
   };
+}
+
+/** Load one team-scoped S3 destination row, assembled, or null. */
+async function loadS3(id: string, teamId: string): Promise<S3Destination | null> {
+  const rows = await getDb()
+    .select()
+    .from(s3Table)
+    .where(and(eq(s3Table.id, id), eq(s3Table.teamId, teamId)))
+    .limit(1);
+  return rows[0] ? assembleS3(rows[0]) : null;
 }
 
 /**
@@ -112,10 +131,13 @@ export function s3TargetFor(s: S3WithSecrets, objectKey: string): S3Target {
 
 export async function listS3(): Promise<S3DestinationDTO[]> {
   const teamId = await requireActiveTeamId();
-  return read()
-    .s3Destinations.filter((s) => s.teamId === teamId)
-    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
-    .map(toDTO);
+  // Newest-first sort pushed into SQL (matches s3_destination_team_created_idx).
+  const rows = await getDb()
+    .select()
+    .from(s3Table)
+    .where(eq(s3Table.teamId, teamId))
+    .orderBy(desc(s3Table.createdAt));
+  return rows.map((r) => toDTO(assembleS3(r)));
 }
 
 export async function createS3(input: {
@@ -147,7 +169,7 @@ export async function createS3(input: {
     status: "unverified",
     createdAt: nowIso(),
   };
-  mutate((d) => d.s3Destinations.push(s));
+  await getDb().insert(s3Table).values(s3ToRow(s));
   await recordActivity("s3", `Connected S3 destination ${s.name}`, user.name, null);
   return toDTO(s);
 }
@@ -167,7 +189,7 @@ export async function createS3(input: {
  */
 export async function testS3(id: string): Promise<S3DestinationDTO> {
   const teamId = (await requireCapability("manage_infra")).teamId;
-  const cur = read().s3Destinations.find((x) => x.id === id && x.teamId === teamId);
+  const cur = await loadS3(id, teamId);
   if (!cur) throw new Error("Not found");
 
   const creds = await getS3WithSecrets(id);
@@ -175,16 +197,18 @@ export async function testS3(id: string): Promise<S3DestinationDTO> {
   // requires one — a sentinel that documents intent.
   const target = s3TargetFor(creds, "deplo/.s3check");
 
+  // The agent probe (RPC) runs BEFORE the status write (PLAN §1 rule (a) — never
+  // inside a transaction); the status is persisted from the live verdict.
   const { ok } = await checkOnAnyBackupAgent(target);
 
-  return toDTO(
-    mutate((d) => {
-      const s = d.s3Destinations.find((x) => x.id === id && x.teamId === teamId);
-      if (!s) throw new Error("Not found");
-      s.status = ok ? "connected" : "error";
-      return s;
-    }),
-  );
+  const status = ok ? "connected" : "error";
+  const updated = await getDb()
+    .update(s3Table)
+    .set({ status })
+    .where(and(eq(s3Table.id, id), eq(s3Table.teamId, teamId)))
+    .returning();
+  if (updated.length === 0) throw new Error("Not found");
+  return toDTO(assembleS3(updated[0]!));
 }
 
 /**
@@ -238,14 +262,30 @@ async function checkOnAnyBackupAgent(
 
 export async function deleteS3(id: string): Promise<void> {
   const { membership } = await requireCapability("manage_infra");
+  const teamId = membership.teamId;
   const user = (await getCurrentUser())!;
-  const s = read().s3Destinations.find(
-    (x) => x.id === id && x.teamId === membership.teamId,
-  );
+  const s = await loadS3(id, teamId);
   if (!s) throw new Error("Not found");
-  mutate((d) => {
-    d.s3Destinations = d.s3Destinations.filter((x) => x.id !== id);
-    d.backups = d.backups.filter((b) => b.destinationId !== id);
+  // `s3_destination` ← `backups.destination_id` / `backup_runs.destination_id` are
+  // both RESTRICT (a destination must never be silently cascade-deleted out from
+  // under live schedules / restore points), so the dependent rows are removed
+  // EXPLICITLY in one transaction (PLAN §1 "deleteS3 (s3_destination + backups
+  // cascade)"). The JSONB version dropped dependent SCHEDULES but orphaned run
+  // history with a dangling destinationId; the RESTRICT FK forbids that, so the
+  // run records go too — this removes only control-plane records, not the S3
+  // objects (the "delete artifacts too" flow handles those separately).
+  await getDb().transaction(async (tx) => {
+    await tx
+      .delete(backupRunsTable)
+      .where(
+        and(eq(backupRunsTable.destinationId, id), eq(backupRunsTable.teamId, teamId)),
+      );
+    await tx
+      .delete(backupsTable)
+      .where(and(eq(backupsTable.destinationId, id), eq(backupsTable.teamId, teamId)));
+    await tx
+      .delete(s3Table)
+      .where(and(eq(s3Table.id, id), eq(s3Table.teamId, teamId)));
   });
   await recordActivity("s3", `Removed S3 destination ${s.name}`, user.name, null);
 }

--- a/lib/db/backfill/cut-sets/backups.test.ts
+++ b/lib/db/backfill/cut-sets/backups.test.ts
@@ -1,0 +1,300 @@
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import type { PGlite } from "@electric-sql/pglite";
+import { count, eq } from "drizzle-orm";
+
+import { buildSeed } from "../../../seed";
+import type { DeploData, Server } from "../../../types";
+import {
+  backups,
+  backupRuns,
+  databases,
+  s3Destination,
+  servers,
+} from "../../schema/control-plane";
+import { makeTestDb, type TestDb } from "../../test-harness";
+import { runBackfill } from "../engine";
+import { backupsCutSetCopy, reconcileBackups } from "./backups";
+import { CUT_SETS, markerExists } from "../markers";
+import { teams as teamsTable } from "../../schema/control-plane";
+import { seedProject, seedServer } from "../../../data/project-graph-test-helpers";
+
+/**
+ * Cut-set (d) runs LAST — identity (b) and the project graph (c) are already
+ * relational when it copies. The backfill itself idempotently seeds teams/users/
+ * servers (so the copy never relies on this), but a project-target backup FKs the
+ * `projects` table (owned by cut-set (c)), so the test seeds that prerequisite the
+ * way production ordering provides it: a team row + a server + the project.
+ */
+async function seedProjectGraphPrereqs(): Promise<void> {
+  await db
+    .insert(teamsTable)
+    .values({ id: "team_a", name: "Alpha", slug: "alpha", plan: "pro", createdAt: T0 })
+    .onConflictDoNothing();
+  await seedServer(db, "srv_1");
+  await seedProject(db, { id: "prj_1", teamId: "team_a", serverId: "srv_1" });
+}
+
+/**
+ * Step 5 backups backfill test (relational-store PLAN §3 cut-set (d) / §7). Drives
+ * the cut-set against pglite: element-granular fidelity across databases + s3 +
+ * backups + backup_runs, the orphan PRUNE (a schedule with a dead target/
+ * destination is dropped; a run with a dead destination is dropped, a run with a
+ * dead target/owning-schedule is kept with those FKs NULLed), seq in source-array
+ * order, idempotent re-run, fresh-install-zero, and rollback-on-reconcile-mismatch.
+ */
+
+let db: TestDb;
+let pg: PGlite;
+
+before(async () => {
+  ({ db, pg } = await makeTestDb());
+});
+
+after(async () => {
+  await pg.close();
+});
+
+beforeEach(async () => {
+  await pg.exec(`
+    truncate table
+      backup_runs, backups, databases, s3_destination,
+      project_build_method_settings, project_build, projects,
+      servers, store_migration, users, teams
+    restart identity cascade;
+  `);
+});
+
+/* ------------------------------------------------------------------ */
+/* Fixture                                                             */
+/* ------------------------------------------------------------------ */
+
+const T0 = "2026-01-01T00:00:00.000Z";
+
+function serverRow(): Server {
+  return {
+    id: "srv_1",
+    name: "srv_1",
+    host: "10.0.0.1",
+    type: "remote",
+    status: "online",
+    ip: "10.0.0.1",
+    dockerVersion: "27",
+    traefikEnabled: true,
+    cpuCores: 4,
+    memoryMb: 8192,
+    diskGb: 100,
+    cpuUsage: 1,
+    memoryUsage: 1,
+    diskUsage: 1,
+    createdAt: T0,
+  };
+}
+
+/** A backups document covering both target kinds + the orphan/prune cases. */
+function backupsFixture(): DeploData {
+  const d = buildSeed();
+  d.teams = [{ id: "team_a", name: "Alpha", slug: "alpha", plan: "pro", createdAt: T0 }];
+  d.servers = [serverRow()];
+  // A live project (cut-set c is relational; the live JSONB still carries it).
+  d.projects = [
+    {
+      id: "prj_1", name: "p1", slug: "p1", teamId: "team_a", folderId: null,
+      serverId: "srv_1", framework: "nextjs", logo: null, source: "github",
+      repo: null, dockerImage: null, upload: null, compose: null, expose: null,
+      exposes: null, mounts: null, volumes: null,
+      build: { framework: "nextjs", buildMethod: "nixpacks", methodSettings: {} } as never,
+      dev: null, productionUrl: null, status: "active", autoDeploy: true,
+      latestDeploymentId: null, createdAt: T0, updatedAt: T0,
+    },
+  ];
+  d.databases = [
+    {
+      id: "db_1", teamId: "team_a", name: "main", type: "postgres", version: "16",
+      status: "running", serverId: "srv_1", host: "db-main", port: 5432,
+      connectionStringEnc: "enc", exposedPublicly: false, sizeMb: 10, createdAt: T0,
+    },
+  ];
+  d.s3Destinations = [
+    {
+      id: "s3_1", teamId: "team_a", name: "Backblaze", provider: "backblaze-b2",
+      endpoint: "https://s3.eu.backblazeb2.com", region: "eu", bucket: "b",
+      accessKeyEnc: "ak", secretKeyEnc: "sk", status: "connected", createdAt: T0,
+    },
+  ];
+  d.backups = [
+    // b1: live database target → kept.
+    {
+      id: "bkp_1", teamId: "team_a", name: "nightly-db", targetKind: "database",
+      databaseId: "db_1", projectId: null, destinationId: "s3_1",
+      schedule: "0 3 * * *", retentionDays: 7, lastRunAt: null, lastStatus: "never",
+      enabled: true, createdAt: T0,
+    },
+    // b2: live project target → kept.
+    {
+      id: "bkp_2", teamId: "team_a", name: "nightly-prj", targetKind: "project",
+      databaseId: null, projectId: "prj_1", destinationId: "s3_1",
+      schedule: "0 4 * * *", retentionDays: 14, lastRunAt: null, lastStatus: "never",
+      enabled: true, createdAt: T0,
+    },
+    // b3: DEAD database target (the deleteDatabase orphan leak) → PRUNED.
+    {
+      id: "bkp_dead_target", teamId: "team_a", name: "dead", targetKind: "database",
+      databaseId: "db_gone", projectId: null, destinationId: "s3_1",
+      schedule: "0 5 * * *", retentionDays: 7, lastRunAt: null, lastStatus: "never",
+      enabled: true, createdAt: T0,
+    },
+    // b4: DEAD destination (the deleteS3 legacy orphan) → PRUNED.
+    {
+      id: "bkp_dead_dest", teamId: "team_a", name: "deaddest", targetKind: "database",
+      databaseId: "db_1", projectId: null, destinationId: "s3_gone",
+      schedule: "0 6 * * *", retentionDays: 7, lastRunAt: null, lastStatus: "never",
+      enabled: true, createdAt: T0,
+    },
+  ];
+  d.backupRuns = [
+    // r1, r2: live destination, live db target → kept (seq order preserved).
+    {
+      id: "brun_1", teamId: "team_a", backupId: "bkp_1", targetKind: "database",
+      databaseId: "db_1", projectId: null, destinationId: "s3_1",
+      objectKey: "deplo/team_a/database/db_1/1-brun_1.dump.gz", sizeBytes: 100,
+      status: "success", error: null, startedAt: T0, finishedAt: T0,
+    },
+    {
+      id: "brun_2", teamId: "team_a", backupId: "bkp_1", targetKind: "database",
+      databaseId: "db_1", projectId: null, destinationId: "s3_1",
+      objectKey: "deplo/team_a/database/db_1/2-brun_2.dump.gz", sizeBytes: 200,
+      status: "success", error: null, startedAt: T0, finishedAt: T0,
+    },
+    // r3: live destination but DEAD db target + DEAD owning schedule → kept, FKs NULLed.
+    {
+      id: "brun_orphan_target", teamId: "team_a", backupId: "bkp_gone",
+      targetKind: "database", databaseId: "db_gone", projectId: null,
+      destinationId: "s3_1", objectKey: "deplo/team_a/database/db_gone/x.dump.gz",
+      sizeBytes: 50, status: "success", error: null, startedAt: T0, finishedAt: T0,
+    },
+    // r4: DEAD destination → PRUNED.
+    {
+      id: "brun_dead_dest", teamId: "team_a", backupId: null, targetKind: "database",
+      databaseId: "db_1", projectId: null, destinationId: "s3_gone",
+      objectKey: "x", sizeBytes: 1, status: "failed", error: "x",
+      startedAt: T0, finishedAt: T0,
+    },
+  ];
+  return d;
+}
+
+/* ------------------------------------------------------------------ */
+/* Element-granular fidelity                                            */
+/* ------------------------------------------------------------------ */
+
+test("backups backfill: copies databases + s3 + schedules + runs with fidelity", async () => {
+  await seedProjectGraphPrereqs(); // cut-set (c) ran first → prj_1 is relational
+  const d = backupsFixture();
+  await runBackfill(db, CUT_SETS.backups, d, backupsCutSetCopy);
+
+  assert.equal((await db.select({ n: count() }).from(servers))[0]!.n, 1, "server seeded");
+  assert.equal((await db.select({ n: count() }).from(databases))[0]!.n, 1);
+  assert.equal((await db.select({ n: count() }).from(s3Destination))[0]!.n, 1);
+
+  // backups: b1 + b2 kept; b3 (dead target) + b4 (dead destination) pruned.
+  const sched = await db.select().from(backups).orderBy(backups.id);
+  assert.deepEqual(sched.map((b) => b.id), ["bkp_1", "bkp_2"]);
+  assert.equal(sched.find((b) => b.id === "bkp_2")!.targetKind, "project");
+
+  // backup_runs: r1, r2 kept intact; r3 kept with dead FKs NULLed; r4 pruned.
+  const runs = await db.select().from(backupRuns).orderBy(backupRuns.seq);
+  assert.deepEqual(runs.map((r) => r.id), ["brun_1", "brun_2", "brun_orphan_target"]);
+  // seq reproduces insertion (source-array) order.
+  assert.ok(runs[0]!.seq < runs[1]!.seq && runs[1]!.seq < runs[2]!.seq, "seq is ascending in source order");
+  // r1/r2 keep their live FKs.
+  assert.equal(runs[0]!.databaseId, "db_1");
+  assert.equal(runs[0]!.backupId, "bkp_1");
+  // r3: dead databaseId + dead backupId NULLed, but the run (history) survives.
+  const r3 = runs.find((r) => r.id === "brun_orphan_target")!;
+  assert.equal(r3.databaseId, null, "dead databaseId NULLed");
+  assert.equal(r3.backupId, null, "dead owning-schedule backupId NULLed");
+  assert.equal(r3.destinationId, "s3_1", "live destination kept");
+
+  assert.equal(await markerExists(db, CUT_SETS.backups), true);
+});
+
+/* ------------------------------------------------------------------ */
+/* Idempotent re-run + fresh install                                   */
+/* ------------------------------------------------------------------ */
+
+test("backups backfill: idempotent re-run is a no-op", async () => {
+  await seedProjectGraphPrereqs();
+  const d = backupsFixture();
+  await runBackfill(db, CUT_SETS.backups, d, backupsCutSetCopy);
+  await runBackfill(db, CUT_SETS.backups, d, backupsCutSetCopy);
+  assert.equal((await db.select({ n: count() }).from(backups))[0]!.n, 2);
+  assert.equal((await db.select({ n: count() }).from(backupRuns))[0]!.n, 3);
+});
+
+test("backups backfill: fresh install marks done with zero rows", async () => {
+  const d = buildSeed(); // empty collections
+  await runBackfill(db, CUT_SETS.backups, d, backupsCutSetCopy);
+  assert.equal((await db.select({ n: count() }).from(backups))[0]!.n, 0);
+  assert.equal((await db.select({ n: count() }).from(databases))[0]!.n, 0);
+  assert.equal(await markerExists(db, CUT_SETS.backups), true);
+});
+
+/* ------------------------------------------------------------------ */
+/* Rollback on reconcile mismatch                                       */
+/* ------------------------------------------------------------------ */
+
+test("backups backfill: a reconcile mismatch rolls the whole tx back", async () => {
+  await seedProjectGraphPrereqs();
+  const d = backupsFixture();
+  // Re-reconcile against an INFLATED source (an extra database the copy never
+  // inserted) so the count assert throws → the whole tx rolls back (PLAN §7).
+  const inflated: DeploData = {
+    ...d,
+    databases: [
+      ...d.databases,
+      { ...d.databases[0]!, id: "db_ghost", name: "ghost" },
+    ],
+  };
+  await assert.rejects(
+    () =>
+      runBackfill(db, CUT_SETS.backups, d, async (tx) => {
+        await backupsCutSetCopy(tx, d); // copies the real rows + reconciles OK
+        await reconcileBackups(tx, inflated); // re-reconcile vs tampered → throws
+      }),
+    /reconcile mismatch/,
+  );
+  assert.equal((await db.select({ n: count() }).from(databases))[0]!.n, 0);
+  assert.equal(await markerExists(db, CUT_SETS.backups), false);
+});
+
+/* ------------------------------------------------------------------ */
+/* Legacy hardening — a run whose target project is dead keeps its history */
+/* ------------------------------------------------------------------ */
+
+test("backups backfill: a project run with a dead target keeps history, NULLs projectId", async () => {
+  const d = buildSeed();
+  d.teams = [{ id: "team_a", name: "Alpha", slug: "alpha", plan: "pro", createdAt: T0 }];
+  d.servers = [serverRow()];
+  d.s3Destinations = [
+    {
+      id: "s3_1", teamId: "team_a", name: "S3", provider: "aws",
+      endpoint: "https://s3.amazonaws.com", region: "us-east-1", bucket: "b",
+      accessKeyEnc: "ak", secretKeyEnc: "sk", status: "connected", createdAt: T0,
+    },
+  ];
+  // A project run whose project was deleted (prj_gone not in d.projects).
+  d.backupRuns = [
+    {
+      id: "brun_p", teamId: "team_a", backupId: null, targetKind: "project",
+      databaseId: null, projectId: "prj_gone", destinationId: "s3_1",
+      objectKey: "deplo/team_a/project/prj_gone/x.tar.gz", sizeBytes: 7,
+      status: "success", error: null, startedAt: T0, finishedAt: T0,
+    },
+  ];
+  await runBackfill(db, CUT_SETS.backups, d, backupsCutSetCopy);
+  const rows = await db.select().from(backupRuns).where(eq(backupRuns.id, "brun_p"));
+  assert.equal(rows.length, 1, "the run history survives");
+  assert.equal(rows[0]!.projectId, null, "dead projectId NULLed");
+});

--- a/lib/db/backfill/cut-sets/backups.ts
+++ b/lib/db/backfill/cut-sets/backups.ts
@@ -1,0 +1,267 @@
+import { count, inArray } from "drizzle-orm";
+import type { PgTable } from "drizzle-orm/pg-core";
+
+import type { Backup, BackupRun, DeploData } from "../../../types";
+import {
+  backupToRow,
+  backupRunToRow,
+  databaseToRow,
+  s3ToRow,
+} from "../../../data/backup-rows";
+import {
+  backups,
+  backupRuns,
+  databases,
+  s3Destination,
+  servers,
+} from "../../schema/control-plane";
+import type { CutSetCopy } from "../engine";
+import type { BackfillTx } from "../types";
+import { seedIdentityRoots, seedServers } from "../roots";
+
+/**
+ * Cut-set (d) — backups (relational-store PLAN §3 "Cut-set (d)", Step 5). The data
+ * aggregate: `databases` + `s3_destination` (their FKs are prerequisites of the
+ * schedule/run tables) then `backups` + `backup_runs`, copied from the fresh JSONB
+ * at the cut-set's switch moment. It runs LAST (after identity (b) and the project
+ * graph (c)) because a backup target FKs a database / project / destination, so
+ * those must exist relationally first.
+ *
+ * Backfill specifics (PLAN §7):
+ *  - **FK roots.** Identity (teams/users, cut-set (b)) and `servers` (no cut-set,
+ *    bridged) are seeded idempotently — `databases.server_id` RESTRICTs to a
+ *    server and every collection here carries a NOT-NULL `team_id`.
+ *  - **FK-ordered copy** (PLAN §2): `s3_destination` → `databases` → `backups` →
+ *    `backup_runs`. `backups`/`backup_runs` reference `databases`/`s3_destination`
+ *    (copied here) and `projects` (cut-set (c), already relational).
+ *  - **Orphan prune (the live `deleteProject` bug).** `deleteProject` /
+ *    `deleteDatabase` historically left dangling backup/run target ids; the
+ *    RESTRICT `destination_id` FK and the schedule `target_kind` XOR forbid
+ *    dangling rows, so the copy PRUNES a backup SCHEDULE whose database/project
+ *    target or whose destination is gone (PLAN §7 "prunes orphan project-target
+ *    backups"). A backup_run's `database_id`/`project_id`/`backup_id` are SET NULL
+ *    FKs (history outlives the target), so a dangling one is NULLED rather than
+ *    dropping the run; but its `destination_id` is RESTRICT, so a run whose
+ *    DESTINATION is gone is pruned (no bucket left to reference).
+ *  - **`seq` in source-array order** (PLAN §5). `backup_runs.seq` is a
+ *    `bigint identity` the DB assigns; the copy inserts runs in JSONB array order
+ *    (which encodes `Array.push` order) so `seq` reproduces insertion order and
+ *    retention's `(started_at, seq)` ranking matches the original history.
+ *  - **Reconcile is element-granular** (PLAN §7): row counts AFTER prune, the
+ *    schedule `target_kind` XOR holds, and every FK resolves.
+ *
+ * `migrate()` (run by `normalizeForBackfill` before this copy) already stamped a
+ * legacy row's `teamId` and defaulted a pre-project-backups schedule's
+ * `targetKind`/`projectId`, so the rows reaching here are model-current; this cut-
+ * set only prunes dangling FKs + explodes them into columns.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Copy                                                                */
+/* ------------------------------------------------------------------ */
+
+/** Whether a schedule's target (database OR project) is live. */
+function backupTargetLive(
+  b: Backup,
+  liveDatabaseIds: Set<string>,
+  liveProjectIds: Set<string>,
+): boolean {
+  return b.targetKind === "database"
+    ? !!b.databaseId && liveDatabaseIds.has(b.databaseId)
+    : !!b.projectId && liveProjectIds.has(b.projectId);
+}
+
+async function copyBackups(tx: BackfillTx, data: DeploData): Promise<void> {
+  // FK roots first (PLAN §2 "roots first"). Identity was migrated by cut-set (b);
+  // `servers` is bridged (no cut-set owns it). Seed both idempotently.
+  await seedIdentityRoots(tx, data);
+  await seedServers(tx, data);
+
+  // The live id sets used for orphan pruning. Databases are copied by THIS cut-set
+  // (so the JSONB set is authoritative); projects are relational as of cut-set (c)
+  // but the still-live JSONB carries the same project set at switch time.
+  const liveDatabaseIds = new Set(data.databases.map((d) => d.id));
+  const liveProjectIds = new Set(data.projects.map((p) => p.id));
+  const liveDestinationIds = new Set(data.s3Destinations.map((s) => s.id));
+
+  /* --- s3_destination (FK: teams only) --- */
+  if (data.s3Destinations.length > 0) {
+    await tx.insert(s3Destination).values(data.s3Destinations.map(s3ToRow));
+  }
+
+  /* --- databases (FK: servers RESTRICT + teams) --- */
+  if (data.databases.length > 0) {
+    await tx.insert(databases).values(data.databases.map(databaseToRow));
+  }
+
+  /* --- backups schedules (PRUNE dead target / destination) --- */
+  const liveBackups = data.backups.filter(
+    (b) =>
+      liveDestinationIds.has(b.destinationId) &&
+      backupTargetLive(b, liveDatabaseIds, liveProjectIds),
+  );
+  const liveBackupIds = new Set(liveBackups.map((b) => b.id));
+  if (liveBackups.length > 0) {
+    await tx.insert(backups).values(liveBackups.map(backupToRow));
+  }
+
+  /* --- backup_runs history (PRUNE dead destination; NULL dead target/backup) ---
+     A run keeps its history even after its target/schedule is gone (the SET NULL
+     FKs), so a dangling databaseId/projectId/backupId is NULLED, not dropped. But
+     destination_id is RESTRICT, so a run pointing at a vanished bucket is pruned
+     (there is no destination row left for the FK to resolve). Insert in source-
+     array order so the identity `seq` reproduces insertion order (PLAN §5). */
+  const liveRuns = data.backupRuns
+    .filter((r) => liveDestinationIds.has(r.destinationId))
+    .map((r) => nullDeadRunFks(r, liveDatabaseIds, liveProjectIds, liveBackupIds));
+  if (liveRuns.length > 0) {
+    await tx.insert(backupRuns).values(liveRuns.map(backupRunToRow));
+  }
+
+  await reconcileBackups(tx, data);
+}
+
+/** Null a run's SET-NULL FKs that no longer resolve (target / owning schedule). */
+function nullDeadRunFks(
+  r: BackupRun,
+  liveDatabaseIds: Set<string>,
+  liveProjectIds: Set<string>,
+  liveBackupIds: Set<string>,
+): BackupRun {
+  return {
+    ...r,
+    databaseId: r.databaseId && liveDatabaseIds.has(r.databaseId) ? r.databaseId : null,
+    projectId: r.projectId && liveProjectIds.has(r.projectId) ? r.projectId : null,
+    backupId: r.backupId && liveBackupIds.has(r.backupId) ? r.backupId : null,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Reconcile (element-granular)                                         */
+/* ------------------------------------------------------------------ */
+
+async function rowCount(tx: BackfillTx, table: PgTable): Promise<number> {
+  const r = await tx.select({ n: count() }).from(table);
+  return r[0]?.n ?? 0;
+}
+
+function fail(msg: string): never {
+  // A reconcile mismatch throws so the engine's tx rolls back, the marker is not
+  // written, and the next boot re-runs the copy from the still-live JSONB.
+  throw new Error(`[backfill:backups] reconcile mismatch: ${msg}`);
+}
+
+/**
+ * Element-granular reconciliation of the backups cut-set against the source
+ * `data` (PLAN §7). Counts are AFTER the orphan prune, so the expected values are
+ * computed over the SAME live sets the copy inserted. Exported so a test can drive
+ * a mismatch the DB constraints alone wouldn't catch.
+ */
+export async function reconcileBackups(
+  tx: BackfillTx,
+  data: DeploData,
+): Promise<void> {
+  const liveDatabaseIds = new Set(data.databases.map((d) => d.id));
+  const liveProjectIds = new Set(data.projects.map((p) => p.id));
+  const liveDestinationIds = new Set(data.s3Destinations.map((s) => s.id));
+
+  /* (1) databases + s3_destination — copied whole (FK roots are seeded, no prune). */
+  const dbCount = await rowCount(tx, databases);
+  if (dbCount !== data.databases.length)
+    fail(`databases ${dbCount} != ${data.databases.length}`);
+  const s3Count = await rowCount(tx, s3Destination);
+  if (s3Count !== data.s3Destinations.length)
+    fail(`s3_destination ${s3Count} != ${data.s3Destinations.length}`);
+
+  /* (2) backups schedules — count AFTER the dead-target / dead-destination prune. */
+  const expectedBackups = data.backups.filter(
+    (b) =>
+      liveDestinationIds.has(b.destinationId) &&
+      backupTargetLive(b, liveDatabaseIds, liveProjectIds),
+  );
+  const backupCount = await rowCount(tx, backups);
+  if (backupCount !== expectedBackups.length)
+    fail(`backups ${backupCount} != ${expectedBackups.length}`);
+
+  /* (3) backup_runs history — count AFTER the dead-destination prune. */
+  const expectedRuns = data.backupRuns.filter((r) =>
+    liveDestinationIds.has(r.destinationId),
+  );
+  const runCount = await rowCount(tx, backupRuns);
+  if (runCount !== expectedRuns.length)
+    fail(`backup_runs ${runCount} != ${expectedRuns.length}`);
+
+  /* (4) every kept schedule satisfies the target_kind XOR (exactly one target id,
+        matching the kind) — the DB CHECK enforces it, but assert here so a
+        mis-prune surfaces as a clear reconcile message, not a raw constraint
+        violation. */
+  for (const b of expectedBackups) {
+    const ok =
+      b.targetKind === "database"
+        ? !!b.databaseId && !b.projectId
+        : !!b.projectId && !b.databaseId;
+    if (!ok) fail(`backup ${b.id} violates target_kind XOR`);
+  }
+
+  /* (5) every backup FK resolves: destination (live), and the target id is in the
+        live set for its kind. */
+  for (const b of expectedBackups) {
+    if (!liveDestinationIds.has(b.destinationId))
+      fail(`backup ${b.id} references missing destination ${b.destinationId}`);
+    if (b.targetKind === "database" && !liveDatabaseIds.has(b.databaseId!))
+      fail(`backup ${b.id} references missing database ${b.databaseId}`);
+    if (b.targetKind === "project" && !liveProjectIds.has(b.projectId!))
+      fail(`backup ${b.id} references missing project ${b.projectId}`);
+  }
+
+  /* (6) every kept run's destination resolves, and its NULLed target/backup FKs
+        are consistent with the live sets (a persisted non-null id must be live). */
+  if (expectedRuns.length > 0) {
+    const persistedRuns = await tx
+      .select({
+        id: backupRuns.id,
+        destinationId: backupRuns.destinationId,
+        databaseId: backupRuns.databaseId,
+        projectId: backupRuns.projectId,
+        backupId: backupRuns.backupId,
+      })
+      .from(backupRuns);
+    const liveDestSet = await tx
+      .select({ id: s3Destination.id })
+      .from(s3Destination)
+      .where(inArray(s3Destination.id, [...liveDestinationIds]));
+    const present = new Set(liveDestSet.map((r) => r.id));
+    for (const r of persistedRuns) {
+      if (!present.has(r.destinationId))
+        fail(`backup_run ${r.id} references missing destination ${r.destinationId}`);
+      if (r.databaseId && !liveDatabaseIds.has(r.databaseId))
+        fail(`backup_run ${r.id} kept a dead databaseId ${r.databaseId}`);
+      if (r.projectId && !liveProjectIds.has(r.projectId))
+        fail(`backup_run ${r.id} kept a dead projectId ${r.projectId}`);
+    }
+  }
+
+  /* (7) databases FK to servers resolves. */
+  if (data.databases.length > 0) {
+    const serverIds = [...new Set(data.databases.map((d) => d.serverId))];
+    const presentServers = new Set(
+      (
+        await tx
+          .select({ id: servers.id })
+          .from(servers)
+          .where(inArray(servers.id, serverIds))
+      ).map((r) => r.id),
+    );
+    for (const d of data.databases) {
+      if (!presentServers.has(d.serverId))
+        fail(`database ${d.id} references missing server ${d.serverId}`);
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Export                                                              */
+/* ------------------------------------------------------------------ */
+
+/** The backups cut-set's copy, for {@link runBackfill}. */
+export const backupsCutSetCopy: CutSetCopy = copyBackups;

--- a/lib/db/backfill/cut-sets/project-graph.ts
+++ b/lib/db/backfill/cut-sets/project-graph.ts
@@ -53,7 +53,7 @@ import {
   coerceImageKind,
   sanitizeTargets,
 } from "../normalize";
-import { seedIdentityRoots } from "../roots";
+import { seedIdentityRoots, seedServers } from "../roots";
 
 /**
  * Cut-set (c) — project graph (relational-store PLAN §3 "Cut-set (c)", Step 4).
@@ -297,41 +297,6 @@ async function copyProjectGraph(tx: BackfillTx, data: DeploData): Promise<void> 
   // volume ids and the structural-equality check would fail forever (a permanent
   // rollback loop). Threading the one array makes copy and reconcile agree.
   await reconcileProjectGraph(tx, data, liveProjects);
-}
-
-/** Seed the `servers` rows a project's RESTRICT FK references, idempotently. */
-async function seedServers(tx: BackfillTx, data: DeploData): Promise<void> {
-  if (data.servers.length === 0) return;
-  await tx
-    .insert(servers)
-    .values(
-      data.servers.map((s) => ({
-        id: s.id,
-        name: s.name,
-        host: s.host,
-        type: s.type,
-        status: s.status,
-        ip: s.ip,
-        dockerVersion: s.dockerVersion,
-        traefikEnabled: s.traefikEnabled,
-        cpuCores: s.cpuCores,
-        memoryMb: s.memoryMb,
-        diskGb: s.diskGb,
-        cpuUsage: s.cpuUsage,
-        memoryUsage: s.memoryUsage,
-        diskUsage: s.diskUsage,
-        agentPort: s.agent?.port ?? null,
-        agentCertFingerprint: s.agent?.certFingerprint ?? null,
-        agentCertPem: s.agent?.certPem ?? null,
-        agentVersion: s.agent?.version ?? null,
-        bootstrapTokenHash: s.bootstrap?.tokenHash ?? null,
-        bootstrapExpiresAt: s.bootstrap?.expiresAt ?? null,
-        bootstrapUsedAt: s.bootstrap?.usedAt ?? null,
-        lastSeenAt: s.lastSeenAt ?? null,
-        createdAt: s.createdAt,
-      })),
-    )
-    .onConflictDoNothing();
 }
 
 /* ------------------------------------------------------------------ */

--- a/lib/db/backfill/roots.ts
+++ b/lib/db/backfill/roots.ts
@@ -1,5 +1,5 @@
 import type { DeploData } from "../../types";
-import { teams, users } from "../schema/control-plane";
+import { servers, teams, users } from "../schema/control-plane";
 import type { BackfillTx } from "./types";
 
 /**
@@ -62,4 +62,53 @@ export async function seedIdentityRoots(
       )
       .onConflictDoNothing();
   }
+}
+
+/**
+ * Idempotently seed the `servers` rows a cut-set's RESTRICT FKs reference
+ * (`projects.server_id` for cut-set (c); `databases.server_id` for cut-set (d)).
+ *
+ * `servers` is owned by NO cut-set yet (it is instance-wide infra, still
+ * JSONB-authoritative through the `server-row.ts` bridge), but both cut-sets'
+ * RESTRICT FKs need the rows present, so each seeds them from the JSONB at switch
+ * time. `ON CONFLICT DO NOTHING` makes the two cut-sets' seeds (and the live
+ * bridge's mirror-writes) compose without clobbering — whichever runs first
+ * inserts, the rest no-op. Values come straight from the JSONB (the agent /
+ * bootstrap nested objects flattened to columns), NOT re-normalized.
+ */
+export async function seedServers(
+  tx: BackfillTx,
+  data: DeploData,
+): Promise<void> {
+  if (data.servers.length === 0) return;
+  await tx
+    .insert(servers)
+    .values(
+      data.servers.map((s) => ({
+        id: s.id,
+        name: s.name,
+        host: s.host,
+        type: s.type,
+        status: s.status,
+        ip: s.ip,
+        dockerVersion: s.dockerVersion,
+        traefikEnabled: s.traefikEnabled,
+        cpuCores: s.cpuCores,
+        memoryMb: s.memoryMb,
+        diskGb: s.diskGb,
+        cpuUsage: s.cpuUsage,
+        memoryUsage: s.memoryUsage,
+        diskUsage: s.diskUsage,
+        agentPort: s.agent?.port ?? null,
+        agentCertFingerprint: s.agent?.certFingerprint ?? null,
+        agentCertPem: s.agent?.certPem ?? null,
+        agentVersion: s.agent?.version ?? null,
+        bootstrapTokenHash: s.bootstrap?.tokenHash ?? null,
+        bootstrapExpiresAt: s.bootstrap?.expiresAt ?? null,
+        bootstrapUsedAt: s.bootstrap?.usedAt ?? null,
+        lastSeenAt: s.lastSeenAt ?? null,
+        createdAt: s.createdAt,
+      })),
+    )
+    .onConflictDoNothing();
 }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -151,6 +151,7 @@ async function runCutSetBackfills(): Promise<void> {
   const { projectGraphCutSetCopy } = await import(
     "./db/backfill/cut-sets/project-graph"
   );
+  const { backupsCutSetCopy } = await import("./db/backfill/cut-sets/backups");
   const { CUT_SETS } = await import("./db/backfill/markers");
   const db = getDb();
   const owner = `pid-${process.pid}`;
@@ -174,6 +175,14 @@ async function runCutSetBackfills(): Promise<void> {
   // and migrates the team ordering arrays to the junctions.
   await awaitBackfill(db, CUT_SETS.projectGraph, owner, () =>
     runBackfill(db, CUT_SETS.projectGraph, doc, projectGraphCutSetCopy),
+  );
+
+  // Cut-set (d) — backups (Step 5). Ordered LAST: a backup target FKs a database /
+  // project / destination, so it copies `s3_destination` + `databases` first, then
+  // `backups` + `backup_runs`, pruning schedules with a dead target/destination and
+  // NULLing a run's dead target/owning-schedule FKs.
+  await awaitBackfill(db, CUT_SETS.backups, owner, () =>
+    runBackfill(db, CUT_SETS.backups, doc, backupsCutSetCopy),
   );
 }
 


### PR DESCRIPTION
Migrate the data aggregate (`databases` + `s3_destination` + `backups` + `backup_runs`) from the single JSONB document to relational tables, the last cut-set of the relational-store migration (PLAN §3 cut-set (d) / Step 5).

- lib/data/backup-rows.ts: the ONE row↔object assembler seam (assemble*/​*ToRow, exhaustive via `satisfies`), shared by the data layer + scheduler + backfill. Isolates the seq asymmetry (BackupRun has no seq; backup_runs has a bigint identity seq).
- Retention seq tiebreak (PLAN §5): selectDoomedRuns ranks newest-first by (startedAt, seq) DESC so a same-millisecond tie can't S3Delete the wrong object; listBackupRuns pushes ORDER BY into SQL.
- executeBackup stays two short transactions (start / terminal) with the agent dump + retention s3Delete BETWEEN them, never inside a tx (PLAN §1 rule (a)).
- deleteDatabase: one DELETE, agent teardown outside it; backups.database_id CASCADE removes schedules, backup_runs.database_id SET NULL keeps history.
- deleteS3: one tx deleting dependent runs + schedules explicitly (destination_id is RESTRICT — no silent cascade, no orphaned run history).
- lib/db/backfill/cut-sets/backups.ts: FK-ordered copy (s3 → databases → backups → backup_runs), prunes dead-target/dead-destination schedules, NULLs a run's dead target/owning-schedule FKs (history outlives them), inserts runs in source-array order so seq reproduces insertion order; element-granular reconcile. seedServers extracted to roots.ts (shared with cut-set c).
- reconcileInFlightBackupRuns sync→async; instrumentation.ts awaits it before the scheduler. scheduler reads enabled schedules relationally.
- Tests: data-layer (databases/s3/backups), backfill fidelity + prune + rollback, retention seq-tiebreak unit tests, scheduler rewritten onto the pglite harness.

Full suite 480 pass / 0 fail; tsc clean (pre-existing migrate.test cast only); eslint clean; db:generate reports no schema changes (Step 1 emitted the tables).