### PR TITLE
Fix whitespace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Deplo is that experience on hardware you own and a bill you control. A VPS and a
 and the platform does the operator's job: builds, routing, TLS, databases, backups,
 monitoring, rollbacks. No per-seat pricing, no build minutes, no black box, no vendor
 lock-in. **The shell stays available for experts and is never required to get full value.**
- 
+
 ## ✨ Features
 
 |     | Feature                   | What you get                                                                                                                                                                                            |


### PR DESCRIPTION
Removed extra whitespace in the README file.

## What this changes

<!-- One or two sentences. If it fixes an issue, write "Fixes #123". -->

## How you tested it

<!-- What you actually ran or clicked. "The tests pass" on its own is not a test of the change. -->

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test` passes (with `DEPLO_DATABASE_URL` unset)
- [x] `bunx next typegen && bunx tsc --noEmit` passes
- [x] I regenerated `schema.graphql` if I touched `lib/graphql/types/*`
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and signed the [CLA](../CLA.md) (the bot asks below on your first pull request)
- [x] This does not make the control plane touch Docker or a host directly (see [AGENTS.md](../AGENTS.md))
