### PR TITLE
feat(mcp): expose template deploy tools

### DIFF
--- a/lib/data/apps.ts
+++ b/lib/data/apps.ts
@@ -115,6 +115,7 @@ import { requireFolderCapability } from "./folder-access";
 import { defaultEnvironmentFor } from "./projects";
 import {
   resolveServerIp,
+  productionDomain,
   instanceHost,
   rehostNip,
   rehostBlueprintHosts,
@@ -129,6 +130,9 @@ import { removeUploads } from "../deploy/upload";
 import { isValidLogoValue } from "../apps/logo-shared";
 import { detectAppFavicon } from "../apps/favicon-detect";
 import { faviconSourceKind } from "../apps/favicon-shared";
+import { getTemplateBlueprint } from "../templates-blueprint";
+import { DEFAULT_VARIANT_SLUG } from "@/templates/types";
+import { getTemplateVariant, templateLogoDataUri } from "@/templates/catalog";
 import {
   detectRepoFramework,
   type RepoBuildHints,
@@ -658,6 +662,17 @@ export interface CreateAppInput {
    * Not exposed over GraphQL: it is a property of the import, not a choice an
    * API client makes about one app.
    */
+  deploy?: boolean;
+}
+
+export interface CreateAppFromTemplateInput {
+  templateSlug: string;
+  variantSlug?: string;
+  name?: string;
+  serverId?: string;
+  projectId?: string;
+  environmentId?: string;
+  folderId?: string;
   deploy?: boolean;
 }
 
@@ -1273,6 +1288,46 @@ export async function createApp(input: CreateAppInput): Promise<AppSummary> {
   }
 
   return summarizeOne((await loadAppGraph(project.id))!);
+}
+
+export async function createAppFromTemplate(
+  input: CreateAppFromTemplateInput,
+): Promise<AppSummary> {
+  const template = await getTemplateVariant(
+    input.templateSlug,
+    input.variantSlug?.trim() || DEFAULT_VARIANT_SLUG,
+  );
+  if (!template) throw new Error("That template or variant isn't available.");
+
+  const autoDomain = productionDomain(template.slug, instanceHost());
+  const blueprint = getTemplateBlueprint(template, { domain: autoDomain });
+  const logo = await templateLogoDataUri(template.variant.logo);
+
+  return createApp({
+    name: input.name?.trim() || template.name,
+    source: "compose",
+    repo: null,
+    logo,
+    compose: blueprint.compose,
+    env: blueprint.env,
+    autoDeploy: false,
+    composeService: blueprint.expose?.service ?? null,
+    composePort: blueprint.expose?.port ?? null,
+    extraDomains: blueprint.exposes.slice(1).map((expose) => ({
+      service: expose.service,
+      port: expose.port,
+      host: expose.host ?? "",
+      path: expose.path ?? null,
+    })),
+    autoDomain,
+    autoDomainPath: blueprint.expose?.path ?? null,
+    mounts: blueprint.mounts,
+    serverId: input.serverId,
+    projectId: input.projectId ?? null,
+    environmentId: input.environmentId ?? null,
+    folderId: input.folderId ?? null,
+    deploy: input.deploy ?? false,
+  });
 }
 
 export async function updateAppBuild(

--- a/lib/graphql/types/templates.ts
+++ b/lib/graphql/types/templates.ts
@@ -1,8 +1,135 @@
 import { revalidateTag } from "next/cache";
 import { builder } from "../builder";
+import { matchesQuery } from "@/lib/match-query";
+import {
+  createAppFromTemplate,
+  type CreateAppFromTemplateInput,
+} from "@/lib/data/apps";
+import { listCatalog } from "@/templates/catalog";
+import { AppRef } from "./app";
+
+interface TemplateVariantSummary {
+  templateSlug: string;
+  variantSlug: string;
+  name: string;
+  variantName: string;
+  category: string;
+  shortDescription: string;
+  docsUrl: string | null;
+}
+
+const TemplateVariantSummaryRef = builder
+  .objectRef<TemplateVariantSummary>("TemplateVariantSummary")
+  .implement({
+    description:
+      "A compact, deployable variant from the public template catalog.",
+    fields: (t) => ({
+      templateSlug: t.exposeString("templateSlug"),
+      variantSlug: t.exposeString("variantSlug"),
+      name: t.exposeString("name"),
+      variantName: t.exposeString("variantName"),
+      category: t.exposeString("category"),
+      shortDescription: t.exposeString("shortDescription"),
+      docsUrl: t.exposeString("docsUrl", { nullable: true }),
+    }),
+  });
+
+function flattenTemplateVariants(
+  catalog: Awaited<ReturnType<typeof listCatalog>>,
+  q?: string,
+  category?: string,
+): TemplateVariantSummary[] {
+  const categorySlug = category?.trim().toLowerCase();
+  const query = q?.trim();
+
+  return catalog.flatMap((template) =>
+    template.variants
+      .filter(
+        (variant) => !categorySlug || variant.category.slug === categorySlug,
+      )
+      .filter(
+        (variant) =>
+          !query ||
+          matchesQuery(
+            query,
+            template.name,
+            template.slug,
+            variant.name,
+            variant.slug,
+            variant.shortDescription,
+            variant.category.name,
+            variant.category.slug,
+          ),
+      )
+      .map((variant) => ({
+        templateSlug: template.slug,
+        variantSlug: variant.slug,
+        name: template.name,
+        variantName: variant.name,
+        category: variant.category.name,
+        shortDescription: variant.shortDescription,
+        docsUrl: variant.links.docs?.[0] ?? null,
+      })),
+  );
+}
+
+const CreateAppFromTemplateInputType = builder.inputType(
+  "CreateAppFromTemplateInput",
+  {
+    fields: (t) => ({
+      templateSlug: t.string({
+        required: true,
+        description: "The catalog template slug from templateVariants.",
+      }),
+      variantSlug: t.string({
+        required: false,
+        description: 'The variant slug. Omitted uses the "default" variant.',
+      }),
+      name: t.string({
+        required: false,
+        description: "The new App name. Omitted uses the template name.",
+      }),
+      serverId: t.string({ required: false }),
+      projectId: t.string({ required: false }),
+      environmentId: t.string({ required: false }),
+      folderId: t.string({ required: false }),
+      deploy: t.boolean({
+        required: false,
+        description:
+          "Request the first deployment. Defaults to false; a token also needs deploy_apps.",
+      }),
+    }),
+  },
+);
+
+builder.queryFields((t) => ({
+  templateVariants: t.field({
+    type: [TemplateVariantSummaryRef],
+    authScopes: { loggedIn: true },
+    description:
+      "List the compact deployable variants in the public template catalog.",
+    args: {
+      q: t.arg.string({
+        required: false,
+        description:
+          "Keep variants whose template, variant, category or description matches.",
+      }),
+      category: t.arg.string({
+        required: false,
+        description: "Filter by the category slug.",
+      }),
+    },
+    resolve: async (_root, { q, category }) =>
+      flattenTemplateVariants(
+        await listCatalog(),
+        q ?? undefined,
+        category ?? undefined,
+      ),
+  }),
+}));
 
 /* ------------------------------------------------------------------ */
-/* Mutations                                                           */
+/* Mutations                                                          */
 /* ------------------------------------------------------------------ */
 
 builder.mutationFields((t) => ({
@@ -18,5 +145,26 @@ builder.mutationFields((t) => ({
       revalidateTag("templates", { expire: 0 });
       return true;
     },
+  }),
+  createAppFromTemplate: t.field({
+    type: AppRef,
+    authScopes: { capability: "create_apps" },
+    args: {
+      input: t.arg({
+        type: CreateAppFromTemplateInputType,
+        required: true,
+      }),
+    },
+    resolve: (_root, { input }) =>
+      createAppFromTemplate({
+        templateSlug: input.templateSlug,
+        variantSlug: input.variantSlug ?? undefined,
+        name: input.name ?? undefined,
+        serverId: input.serverId ?? undefined,
+        projectId: input.projectId ?? undefined,
+        environmentId: input.environmentId ?? undefined,
+        folderId: input.folderId ?? undefined,
+        deploy: input.deploy ?? false,
+      } satisfies CreateAppFromTemplateInput),
   }),
 }));

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -151,6 +151,40 @@ const DEPLOYMENT_FIELDS = /* GraphQL */ `
 
 const APPS_READ: McpToolDef[] = [
   tool({
+    name: "list_templates",
+    title: "List templates",
+    description:
+      "List compact deployable variants from the public template catalog. Each row identifies the family with templateSlug and the selectable variant with variantSlug.",
+    group: "Apps",
+    requires: "view",
+    readOnly: true,
+    idempotent: true,
+    paginate: true,
+    input: z.object({
+      q: z
+        .string()
+        .optional()
+        .describe(
+          "Keep variants whose template, variant, category or description matches.",
+        ),
+      category: z.string().optional().describe("Filter by category slug."),
+      ...page,
+    }),
+    query: /* GraphQL */ `
+      query McpListTemplates($q: String, $category: String) {
+        templateVariants(q: $q, category: $category) {
+          templateSlug
+          variantSlug
+          name
+          variantName
+          category
+          shortDescription
+          docsUrl
+        }
+      }
+    `,
+  }),
+  tool({
     name: "list_apps",
     title: "List apps",
     description:
@@ -482,6 +516,55 @@ const APPS_OPS: McpToolDef[] = [
  * ------------------------------------------------------------------ */
 
 const APPS_CONFIG: McpToolDef[] = [
+  tool({
+    name: "create_app_from_template",
+    title: "Create an app from a template",
+    description:
+      "Create an idle App from a public catalog template. Set deploy=true to request its first deployment. Generated credentials are stored in the App Variables and are never returned by this tool.",
+    group: "Apps",
+    requires: "create_apps",
+    input: z.object({
+      templateSlug: z
+        .string()
+        .describe("The templateSlug from list_templates."),
+      variantSlug: z
+        .string()
+        .optional()
+        .describe('The variantSlug. Omit to use the "default" variant.'),
+      name: z
+        .string()
+        .optional()
+        .describe("The new App name. Omit to use the template name."),
+      serverId: z.string().optional(),
+      projectId: z.string().optional(),
+      environmentId: z.string().optional(),
+      folderId: z.string().optional(),
+      deploy: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "Request the first deployment. Defaults to false; a token also needs deploy_apps.",
+        ),
+    }),
+    query: /* GraphQL */ `
+      mutation McpCreateAppFromTemplate($input: CreateAppFromTemplateInput!) {
+        createAppFromTemplate(input: $input) { ${APP_FIELDS} }
+      }
+    `,
+    variables: (a) => ({
+      input: {
+        templateSlug: a.templateSlug,
+        variantSlug: a.variantSlug,
+        name: a.name,
+        serverId: a.serverId,
+        projectId: a.projectId,
+        environmentId: a.environmentId,
+        folderId: a.folderId,
+        deploy: a.deploy ?? false,
+      },
+    }),
+  }),
   tool({
     name: "create_app",
     title: "Create an app",

--- a/schema.graphql
+++ b/schema.graphql
@@ -923,6 +923,26 @@ type ContainerMetricsSample {
   ts: Float
 }
 
+input CreateAppFromTemplateInput {
+  """
+  Request the first deployment. Defaults to false; a token also needs deploy_apps.
+  """
+  deploy: Boolean
+  environmentId: String
+  folderId: String
+
+  """The new App name. Omitted uses the template name."""
+  name: String
+  projectId: String
+  serverId: String
+
+  """The catalog template slug from templateVariants."""
+  templateSlug: String!
+
+  """The variant slug. Omitted uses the "default" variant."""
+  variantSlug: String
+}
+
 input CreateAppInput {
   autoDeploy: Boolean
   autoDomain: String
@@ -2774,6 +2794,7 @@ type Mutation {
   """
   connectGitProvider(input: ConnectGitProviderInput!): GitConnection
   createApp(input: CreateAppInput!): App
+  createAppFromTemplate(input: CreateAppFromTemplateInput!): App
 
   """Create a backup schedule. Returns true."""
   createBackup(input: CreateBackupInput!): Boolean
@@ -4310,6 +4331,17 @@ type Query {
   """Every role of the active team - defaults first, then the team's own."""
   teamRoles: [TeamRole!]
 
+  """List the compact deployable variants in the public template catalog."""
+  templateVariants(
+    """Filter by the category slug."""
+    category: String
+
+    """
+    Keep variants whose template, variant, category or description matches.
+    """
+    q: String
+  ): [TemplateVariantSummary!]
+
   """
   Check the upstream repository for a newer Deplo release; cached for an hour.
   """
@@ -5332,6 +5364,17 @@ type TeamRole {
   Where in the team this role reaches. Null means the whole of it, which is every role until one is limited. A scoped role also loses every capability that only means something team-wide.
   """
   scope: RoleScope
+}
+
+"""A compact, deployable variant from the public template catalog."""
+type TemplateVariantSummary {
+  category: String
+  docsUrl: String
+  name: String
+  shortDescription: String
+  templateSlug: String
+  variantName: String
+  variantSlug: String
 }
 
 """


### PR DESCRIPTION
## What this changes

Adds first-party MCP support for Deplo templates. Agents can list deployable template variants in a compact flat shape and create an App from a selected variant; the initial deployment is explicit and defaults to idle.

## How you tested it

- Ran `bun run gen:schema`.
- Ran `bunx next typegen && bunx tsc --noEmit`.
- Ran `bun run lint`: 0 errors; 29 pre-existing warnings.
- Ran `bun run format:check` and `git diff --check`.
- Ran `env -u DEPLO_DATABASE_URL bun run test`: 3849 passed, 0 failed.
- Validated all 76 MCP GraphQL documents against the generated schema.
- Smoke-tested the remote template catalog: 1 family and 2 variants, including the default variant.
- No new test files were added: the MCP documents are validated against the schema, the existing MCP and createApp capability coverage exercises the shared paths, and the remote catalog is checked with a smoke test; a new fixture would require mocking the remote catalog service.

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test` passes (with `DEPLO_DATABASE_URL` unset)
- [x] `bunx next typegen && bunx tsc --noEmit` passes
- [x] I added tests for the new behaviour, or said in the pull request why it cannot be tested
- [x] I regenerated `schema.graphql` if I touched `lib/graphql/types/*`
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and signed the [CLA](../CLA.md) (the bot asks below on your first pull request)
- [x] This does not make the control plane touch Docker or a host directly (see [AGENTS.md](../AGENTS.md))