### PR TITLE
feat(templates): show pre-deploy alerts

### DIFF
--- a/app/(focus)/[team]/new/page.tsx
+++ b/app/(focus)/[team]/new/page.tsx
@@ -195,6 +195,7 @@ export default async function NewAppPage(props: PageProps<"/[team]/new">) {
                     ? template.variant.name
                     : undefined,
                 description: template.variant.shortDescription,
+                alerts: template.variant.alerts,
                 logo,
                 veil,
                 compose: blueprint?.compose ?? "",

--- a/components/apps/new-app-wizard.tsx
+++ b/components/apps/new-app-wizard.tsx
@@ -7,9 +7,12 @@ import { toast } from "sonner";
 import {
   GitBranch,
   FileText,
+  Info,
+  OctagonAlert,
   Server as ServerIcon,
   Pencil,
   ShieldAlert,
+  TriangleAlert,
   Variable,
 } from "lucide-react";
 
@@ -132,6 +135,11 @@ export interface WizardTemplate {
   name: string;
   variantName?: string;
   description: string;
+  alerts: {
+    type: "info" | "warning" | "destructive";
+    message: string;
+    link?: string;
+  }[];
   logo: string | null;
   /** What the logo's pixels said: the hue to wash its tile in, the plate it
    *  needs to be visible. Read server-side, same as the template store's. */
@@ -1062,6 +1070,8 @@ export function NewAppWizard({
               </div>
             )}
 
+            {isTemplate && <TemplateAlerts alerts={template!.alerts} />}
+
             {useCompose && !isTemplate && (
               <ComposeSummary
                 services={composeServices}
@@ -1207,6 +1217,55 @@ function detailsDescription(source: DeploySource): string {
   return (
     SOURCE_TABS.find((t) => t.id === source)?.blurb ??
     "Where your code or image comes from."
+  );
+}
+
+function TemplateAlerts({ alerts }: { alerts: WizardTemplate["alerts"] }) {
+  if (!alerts.length) return null;
+
+  const styles = {
+    info: {
+      icon: Info,
+      className: "border-info/40 bg-info/10 text-info",
+    },
+    warning: {
+      icon: TriangleAlert,
+      className: "border-warning/40 bg-warning/10 text-warning",
+    },
+    destructive: {
+      icon: OctagonAlert,
+      className: "border-destructive/40 bg-destructive/10 text-destructive",
+    },
+  } as const;
+
+  return (
+    <div className="space-y-3">
+      {alerts.map((alert, index) => {
+        const style = styles[alert.type];
+        const Icon = style.icon;
+        return (
+          <div
+            key={`${alert.type}-${index}`}
+            className={`flex items-start gap-3 rounded-lg border px-4 py-3 text-sm ${style.className}`}
+          >
+            <Icon className="mt-0.5 size-4 shrink-0" />
+            <p className="min-w-0 flex-1">
+              {alert.message}{" "}
+              {alert.link && (
+                <a
+                  href={alert.link}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium text-foreground underline underline-offset-4"
+                >
+                  Learn more
+                </a>
+              )}
+            </p>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 

--- a/templates/schema.ts
+++ b/templates/schema.ts
@@ -51,6 +51,14 @@ const apiTemplateLinksSchema = z
   .strict()
   .refine((links) => Object.values(links).some(Boolean));
 
+const apiTemplateAlertSchema = z
+  .object({
+    type: z.enum(["info", "warning", "destructive"]),
+    message: z.string().trim().min(1).max(2_000),
+    link: httpsUrlSchema.optional(),
+  })
+  .strict();
+
 const apiTemplateVariantFilesSchema = z
   .object({
     config: z
@@ -74,6 +82,7 @@ export const apiTemplateVariantSchema = z
     developedBy: apiLinkSchema,
     submittedBy: apiLinkSchema,
     links: apiTemplateLinksSchema,
+    alerts: z.array(apiTemplateAlertSchema).default([]),
     lastUpdate: z.iso.datetime(),
     createdAt: z.iso.datetime(),
     description: z.string().min(20).max(20_000),


### PR DESCRIPTION
## What this changes

Adds validated pre-deploy alerts to remote template variants and renders one banner per alert in the template deployment wizard. Alerts support `info`, `warning` and `destructive` styles, remain deploy-only, and are not persisted on Apps.

## How you tested it

- `bunx next typegen`
- `bunx tsc --noEmit`
- targeted Prettier check on changed files
- `git diff --check`
- No browser verification was run locally; no test file was added because this is presentation-only behavior.

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test` passes (with `DEPLO_DATABASE_URL` unset)
- [x] `bunx next typegen && bunx tsc --noEmit` passes
- [x] I added tests for the new behaviour, or explained above why no test file was added
- [x] I regenerated `schema.graphql` if I touched `lib/graphql/types/*` (not applicable)
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and signed the [CLA](../CLA.md)
- [x] This does not make the control plane touch Docker or a host directly (see [AGENTS.md](../AGENTS.md))
- [ ] I made the pull request for the [docs](https://github.com/DeploCloud/docs) changes where needed