### PR TITLE
fix(apps): show add domain action

### DIFF
--- a/app/(dashboard)/[team]/apps/[slug]/page.tsx
+++ b/app/(dashboard)/[team]/apps/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
   ScrollText,
   ExternalLink,
   ArrowRight,
+  Plus,
 } from "lucide-react";
 import { getAppBySlug } from "@/lib/data/apps";
 import { hasAppCapability } from "@/lib/data/node-access";
@@ -93,7 +94,7 @@ export default async function AppOverview(
               <div className="space-y-4">
                 <div>
                   <p className="text-xs text-muted-foreground">Domain</p>
-                  {project.productionUrl && (
+                  {project.productionUrl ? (
                     <a
                       href={project.productionUrl}
                       target="_blank"
@@ -102,6 +103,8 @@ export default async function AppOverview(
                     >
                       {project.productionUrl.replace(/^https?:\/\//, "")}
                     </a>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No domain</p>
                   )}
                 </div>
                 <div>
@@ -182,7 +185,7 @@ export default async function AppOverview(
                       Build Logs
                     </Link>
                   </Button>
-                  {project.productionUrl && (
+                  {project.productionUrl ? (
                     <Button size="sm" variant="outline" asChild>
                       <a
                         href={project.productionUrl}
@@ -192,6 +195,13 @@ export default async function AppOverview(
                         <ExternalLink className="size-4" />
                         Visit
                       </a>
+                    </Button>
+                  ) : (
+                    <Button size="sm" variant="outline" asChild>
+                      <Link href={`/apps/${slug}/domains`}>
+                        <Plus className="size-4" />
+                        Add domain
+                      </Link>
                     </Button>
                   )}
                 </div>


### PR DESCRIPTION
## What this changes

The Production Deployment card now shows `No domain` when an App has no production domain. Its `Visit` action becomes `Add domain` with a plus icon and links to the App Domains page. Apps with a domain keep the existing `Visit` action.

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test` passes (with `DEPLO_DATABASE_URL` unset)
- [x] `bunx next typegen && bunx tsc --noEmit` passes
- [x] I added tests for the new behaviour, or said in the pull request why it cannot be tested — this is a server-rendered conditional UI copy/link change with no new data or domain logic; no test file was added
- [x] I regenerated `schema.graphql` if I touched `lib/graphql/types/*` — not applicable
- [x] I read `CONTRIBUTING.md` and signed the `CLA`
- [x] This does not make the control plane touch Docker or a host directly
- [ ] I made the pull request for the docs changes where needed — no docs change is needed; the existing domain guide covers the workflow

Does this need a docs page? No: this only makes the existing domain-management path visible from the Production Deployment card.