### PR TITLE
feat(templates): create apps without deploy

### DIFF
--- a/app/(dashboard)/[team]/templates/[slug]/page.tsx
+++ b/app/(dashboard)/[team]/templates/[slug]/page.tsx
@@ -3,10 +3,18 @@ import {
   ArrowLeft,
   ArrowUpRight,
   BookOpen,
+  ChevronDown,
   CloudOff,
   Globe,
+  Plus,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { EmptyState } from "@/components/shared/empty-state";
 import { GitHubIcon } from "@/components/shared/brand-icons";
@@ -120,6 +128,11 @@ export default async function TemplatePage(
     template: template.slug,
     variant: variant.slug,
   });
+  const createHref = newAppHref(placement, {
+    template: template.slug,
+    variant: variant.slug,
+    deploy: false,
+  });
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-8">
@@ -153,7 +166,11 @@ export default async function TemplatePage(
               }))}
             />
           )}
-          <DeployButton canDeploy={canDeploy} href={deployHref} />
+          <DeployButton
+            canDeploy={canDeploy}
+            href={deployHref}
+            createHref={createHref}
+          />
         </div>
       </div>
 
@@ -261,18 +278,46 @@ function TopBar({ placement }: { placement: OverviewPlacement | null }) {
 function DeployButton({
   canDeploy,
   href,
+  createHref,
 }: {
   canDeploy: boolean;
   href: string;
+  createHref: string;
 }) {
   if (canDeploy)
     return (
-      <Button asChild className="shrink-0 sm:w-32">
-        <Link href={href}>
-          Deploy
-          <ArrowUpRight className="size-4" />
-        </Link>
-      </Button>
+      <div
+        role="group"
+        aria-label="Deployment actions"
+        className="inline-flex shrink-0 overflow-hidden rounded-md shadow-sm"
+      >
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              size="icon"
+              aria-label="More deployment options"
+              className="rounded-none border-r border-primary-foreground/20 px-2 shadow-none"
+            >
+              <ChevronDown className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuItem asChild>
+              <Link href={createHref} className="cursor-pointer">
+                <Plus className="size-4" />
+                Create without deploying
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button asChild className="rounded-none sm:w-32">
+          <Link href={href}>
+            Deploy
+            <ArrowUpRight className="size-4" />
+          </Link>
+        </Button>
+      </div>
     );
   return (
     // A disabled button swallows pointer events, so the tooltip needs a

--- a/app/(focus)/[team]/new/page.tsx
+++ b/app/(focus)/[team]/new/page.tsx
@@ -103,6 +103,7 @@ export default async function NewAppPage(props: PageProps<"/[team]/new">) {
   const variantId = one(params.variant);
   const repoParam = one(params.repo);
   const sourceParam = one(params.source);
+  const shouldDeploy = one(params.deploy) !== "false";
   const presetSource = SOURCES.find((s) => s === sourceParam) ?? null;
 
   // The catalogue is a remote service: an unknown slug, a stale link or a
@@ -210,6 +211,7 @@ export default async function NewAppPage(props: PageProps<"/[team]/new">) {
         presetRepo={repoParam}
         presetName={template?.slug}
         presetSource={presetSource}
+        shouldDeploy={shouldDeploy}
         placement={placement}
         exitHref={exitHref}
       />

--- a/components/apps/new-app-wizard.tsx
+++ b/components/apps/new-app-wizard.tsx
@@ -222,6 +222,7 @@ export function NewAppWizard({
   connections,
   providers,
   isInstanceAdmin,
+  shouldDeploy = true,
   placement,
   exitHref,
 }: {
@@ -241,6 +242,8 @@ export function NewAppWizard({
   providers: GitProviderChoice[];
   /** Gates the connect dialog's "on my own network" option. */
   isInstanceAdmin: boolean;
+  /** Whether to start the app's first deployment after creation. */
+  shouldDeploy?: boolean;
   placement?: WizardPlacement | null;
   /** Where Cancel goes - the Overview drill-in, or the template catalog. */
   exitHref: string;
@@ -608,6 +611,7 @@ export function NewAppWizard({
         port: payloadBuild.port,
       },
       autoDeploy: usesGit ? autoDeploy : false,
+      deploy: shouldDeploy,
       // Where the first domain points: what a template declares, else what
       // the wizard showed the user for their own stack.
       composeService: templateCompose

--- a/lib/data/apps.ts
+++ b/lib/data/apps.ts
@@ -568,11 +568,7 @@ export interface CreateAppInput {
   folderId?: string | null;
   projectId?: string | null;
   environmentId?: string | null;
-  /**
-   * Start the first deployment. Default TRUE. `false` is for a BULK import: the
-   * source still serves those hostnames, so the app is born `idle` instead. Not
-   * exposed over GraphQL - a property of the import, not a choice about one app.
-   */
+  /** Start the first deployment. Defaults to true; false leaves the app idle. */
   deploy?: boolean;
 }
 

--- a/lib/graphql/types/app.ts
+++ b/lib/graphql/types/app.ts
@@ -602,6 +602,10 @@ const CreateAppInputType = builder.inputType("CreateAppInput", {
     }),
     build: t.field({ type: BuildConfigInput, required: false }),
     autoDeploy: t.boolean({ required: false }),
+    deploy: t.boolean({
+      required: false,
+      description: "Whether to start the first deployment. Defaults to true.",
+    }),
     // Template/compose deploys carry these so a one-click template keeps its
     // env, routing, baked domain and config-file mounts (audit-restored: these
     // were silently dropped in the first rewiring pass).
@@ -987,6 +991,7 @@ builder.mutationFields((t) => ({
           ? (remapBuildInput(input.build) as never)
           : undefined,
         autoDeploy: input.autoDeploy ?? undefined,
+        deploy: input.deploy ?? undefined,
         env: input.env?.map((e) => ({
           key: e.key,
           value: e.value,

--- a/lib/overview-links.ts
+++ b/lib/overview-links.ts
@@ -64,13 +64,19 @@ function placementParams(
 /** Link to the new-app wizard, carrying the drill-in it was opened from. */
 export function newAppHref(
   p?: OverviewPlacement | null,
-  opts?: { template?: string; variant?: string; source?: string },
+  opts?: {
+    template?: string;
+    variant?: string;
+    source?: string;
+    deploy?: boolean;
+  },
 ): string {
   const params = placementParams(p);
   if (opts?.template) params.set("template", opts.template);
   if (opts?.variant) params.set("variant", opts.variant);
   // The wizard opens straight on this source - what a dropped archive needs.
   if (opts?.source) params.set("source", opts.source);
+  if (opts?.deploy === false) params.set("deploy", "false");
   const qs = params.toString();
   return qs ? `/new?${qs}` : "/new";
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -989,6 +989,9 @@ input CreateAppInput {
   Extra flags appended to `docker compose up` for a compose stack. Validated against the same allow-list the app's settings use.
   """
   composeUpArgs: String
+
+  """Whether to start the first deployment. Defaults to true."""
+  deploy: Boolean
   dockerImage: String
   env: [AppEnvInput!]
   environmentId: String


### PR DESCRIPTION
## What this changes

Adds a split Deploy action to the template detail page. The left chevron opens a menu with `Create without deploying`, which keeps the selected template and variant and creates the App without starting its first deployment.

## Checklist

- [x] `bun run lint` passes
- [x] `bun run test` passes
- [x] `bunx next typegen && bunx tsc --noEmit` passes
- [x] I added tests for the new behaviour, or said in the pull request why it cannot be tested (no new test files per repository instruction; URL propagation was checked directly)
- [x] I regenerated `schema.graphql` if I touched `lib/graphql/types/*`
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and signed the [CLA](../CLA.md)
- [x] This does not make the control plane touch Docker or a host directly (see [AGENTS.md](../AGENTS.md))
- [ ] I made the pull request for the [docs](https://github.com/DeploCloud/docs) changes where needed (no docs changes required)
